### PR TITLE
Replace the nondescriptive key: items with a descriptive key 

### DIFF
--- a/paths/BuildingCollection.yaml
+++ b/paths/BuildingCollection.yaml
@@ -24,9 +24,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - buildings
                 properties:
-                  items:
+                  buildings:
                     type: array
                     items:
                       $ref: '../schemas/Building.yaml'

--- a/paths/CourseCollection.yaml
+++ b/paths/CourseCollection.yaml
@@ -54,9 +54,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - courses
                 properties:
-                  items:
+                  courses:
                     type: array
                     items:
                       $ref: '../schemas/Course.yaml'

--- a/paths/CourseGroupCollection.yaml
+++ b/paths/CourseGroupCollection.yaml
@@ -61,9 +61,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - course-groups
                 properties:
-                  items:
+                  course-groups:
                     type: array
                     items:
                       $ref: '../schemas/CourseGroup.yaml'

--- a/paths/CourseResultCollection.yaml
+++ b/paths/CourseResultCollection.yaml
@@ -43,9 +43,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - course-results
                 properties:
-                  items:
+                  course-results:
                     type: array
                     items:
                       $ref: '../schemas/CourseResult.yaml'

--- a/paths/EducationalDepartmentCollection.yaml
+++ b/paths/EducationalDepartmentCollection.yaml
@@ -37,9 +37,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - educational-departments
                 properties:
-                  items:
+                  educational-departments:
                     type: array
                     items:
                       $ref: '../schemas/EducationalDepartment.yaml'

--- a/paths/EducationalPlanCollection.yaml
+++ b/paths/EducationalPlanCollection.yaml
@@ -37,9 +37,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - educational-plans
                 properties:
-                  items:
+                  educational-plans:
                     type: array
                     items:
                       $ref: '../schemas/EducationalPlan.yaml'

--- a/paths/FacultyCollection.yaml
+++ b/paths/FacultyCollection.yaml
@@ -31,9 +31,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - faculties
                 properties:
-                  items:
+                  faculties:
                     type: array
                     items:
                       $ref: '../schemas/Faculty.yaml'

--- a/paths/NewsFeedCollection.yaml
+++ b/paths/NewsFeedCollection.yaml
@@ -24,9 +24,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - news-feeds
                 properties:
-                  items:
+                  news-feeds:
                     type: array
                     items:
                       $ref: '../schemas/NewsFeed.yaml'

--- a/paths/NewsItemCollection.yaml
+++ b/paths/NewsItemCollection.yaml
@@ -40,9 +40,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - news-items
                 properties:
-                  items:
+                  news-items:
                     type: array
                     items:
                       $ref: '../schemas/NewsItem.yaml'

--- a/paths/PersonCollection.yaml
+++ b/paths/PersonCollection.yaml
@@ -85,9 +85,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - persons
                 properties:
-                  items:
+                  persons:
                     type: array
                     items:
                       $ref: '../schemas/Person.yaml'

--- a/paths/RoomCollection.yaml
+++ b/paths/RoomCollection.yaml
@@ -36,9 +36,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - rooms
                 properties:
-                  items:
+                  rooms:
                     type: array
                     items:
                       $ref: '../schemas/Room.yaml'

--- a/paths/ScheduleCollection.yaml
+++ b/paths/ScheduleCollection.yaml
@@ -64,9 +64,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - schedules
                 properties:
-                  items:
+                  schedules:
                     type: array
                     items:
                       $ref: '../schemas/Schedule.yaml'

--- a/paths/TestResultCollection.yaml
+++ b/paths/TestResultCollection.yaml
@@ -36,9 +36,9 @@ get:
               _embedded:
                 type: object
                 required:
-                  - items
+                  - test-results
                 properties:
-                  items:
+                  test-results:
                     type: array
                     items:
                       $ref: '../schemas/TestResult.yaml'


### PR DESCRIPTION
The keys are in _embedded in the collection endpoints

This also prevents confusion between the key and the property: "items" in case of an array