### PR TITLE
Adds regex for academicYear fields in CourseOffering and Institution

### DIFF
--- a/schemas/CourseOffering.yaml
+++ b/schemas/CourseOffering.yaml
@@ -20,10 +20,11 @@ properties:
     type: number
     description: The number of students that have already enrolled for this course offering
     format: int32
-    minimum: 0  
+    minimum: 0
   academicYear:
     type: string
     description: The year in which this courseOffering takes place
+    pattern: ^\d{4}-\d{4}$
   period:
     type: string
     description: The period in which this courseOffering is offered

--- a/schemas/Institution.yaml
+++ b/schemas/Institution.yaml
@@ -9,13 +9,13 @@ properties:
     description: id of the institution
   brin:
     type: string
-    description: Brincode of the institution 
+    description: Brincode of the institution
   name:
     type: string
     description: Name of the institution
   description:
     type: string
-    description: Any general description of the institution should clearly mention the type of higher education institution, especially in the case of a binary system. In Dutch; universiteit (university) or hogeschool (university of applied sciences). 
+    description: Any general description of the institution should clearly mention the type of higher education institution, especially in the case of a binary system. In Dutch; universiteit (university) or hogeschool (university of applied sciences).
   academicCalendar:
      type: object
      description: links to academic calenders per year
@@ -23,6 +23,7 @@ properties:
        year:
          type: string
          description: year combination
+         pattern: ^\d{4}-\d{4}$
        calender:
           type: url
           description: Link to the academic calender of the institution (e.g. https://www.roosterrapporten.hu.nl/1718/jaarroosters/HU/timetable_academicyear_calender.pdf)


### PR DESCRIPTION
Adds regex to the academicYear fields so that CourseOffering and Institution specify this the same way as CourseResults.