### PR TITLE
Fix typo - "int" should be "integer"

### DIFF
--- a/v4/schemas/Program.yaml
+++ b/v4/schemas/Program.yaml
@@ -51,7 +51,7 @@ properties:
       - LLM
       - Phd
   lengthOfProgram:
-    type: int
+    type: integer
     description: The duration of this program in months
   levelOfQualification:
     type: string


### PR DESCRIPTION
"int" is not a valid OpenAPI data type. This was detected trying to load the spec with express-openapi-validator.
