### PR TITLE
Add persons me

### DIFF
--- a/v4/paths/PersonMe.yaml
+++ b/v4/paths/PersonMe.yaml
@@ -1,6 +1,8 @@
 get:
   summary: GET /persons/me
   description: Returns the person object for the currently authenticated user.
+  security:
+    - bearerAuth: []
   tags:
     - persons
   responses:
@@ -10,10 +12,15 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Person.yaml'
+    '401':
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:
         application/problem+json:
           schema:
             $ref: '../schemas/Problem.yaml'
-

--- a/v4/paths/PersonMe.yaml
+++ b/v4/paths/PersonMe.yaml
@@ -1,0 +1,19 @@
+get:
+  summary: GET /persons/me
+  description: Returns the person object for the currently authenticated user.
+  tags:
+    - persons
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/Person.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
+

--- a/v4/spec.yaml
+++ b/v4/spec.yaml
@@ -12,7 +12,7 @@ info:
       <figcaption> OOAPI information model that feeds OOAPI specification (click to enlage)</figcaption>
     </figure>
 
-    The model provides an overview of how the objects on which the API is specified are related. The overarching concept educations is not found in the in the end points of the API. The smaller concepts of programOffering, courseOffering and conceptOffering are all found in the offering endpoint. The different types of association can all be found in the association endpoint. 
+    The model provides an overview of how the objects on which the API is specified are related. The overarching concept educations is not found in the in the end points of the API. The smaller concepts of programOffering, courseOffering and conceptOffering are all found in the offering endpoint. The different types of association can all be found in the association endpoint.
 
     The program relations object is not found as a separate endpoint but relations between programs can be found within the program endpoint by expanding that endpoint.
 
@@ -272,7 +272,7 @@ tags:
       ```
   - name: sorting information
     description: |
-      Most endpoints provide sorting. To sort you can sort on the elements that are specified per endpoint. All elements can be sorted ascending by default o descending, 
+      Most endpoints provide sorting. To sort you can sort on the elements that are specified per endpoint. All elements can be sorted ascending by default o descending,
       by adding "-" in front of the element to be sorted. The sorting takes place based on comma separated values. e.g.:
 
       ```
@@ -283,7 +283,7 @@ tags:
       GET /programs?sort=name,-ects
       ```
       provides a list of all programs first sorted on name ascending and ects descending
-      
+
   - name: extension information
     description: |
       Most endpoints can be extended. This can be done by providing the extended information in the designated "ext" area of the endpoint. All users of the OOAPI are encouraged to feed their extensions back to the OOAPI working group so this information can be used as feedback for future versions of the OOAPI.
@@ -309,6 +309,8 @@ paths:
     $ref: paths/Service.yaml
   /persons:
     $ref: paths/PersonCollection.yaml
+  /persons/me:
+    $ref: paths/PersonMe.yaml
   /persons/{personId}:
     $ref: paths/PersonInstance.yaml
   /persons/{personId}/associations:

--- a/v4/spec.yaml
+++ b/v4/spec.yaml
@@ -24,6 +24,7 @@ info:
 
   x-logo:
     url: ../logo.png
+
 tags:
   - name: service metadata
     description: The service API provides additional metadata needed to make the OOAPI fit for this organization.
@@ -302,7 +303,11 @@ tags:
       The OOAPI specifcation relies on the HTTP content negotiation mechanism to specify how a client can request information in a specific (natural) language, and how a server should respond to that request. In short: a client adds an `Accept-Language` header to their request, which the server uses to determine in what language the requested content should be returned. More information about this mechanism can be found at [Mozilla MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language).
 
 
-
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
 
 paths:
   /:


### PR DESCRIPTION
Recently we concluded we need a /persons/me endpoint for the pilot Student mobility. Use case: the guest institution wants to fetch person information from the home institution, but only has a authentication token.

This PR is still a work in progress, but the general idea is:

- Add a new operation: GET /persons/me
- For this operation, an Authorization header is required
- Based on this header the implemented service should determine which person is authenticated, only these person details should be returned.
