### PR TITLE
Fix incorrect error responses and error documentation

### DIFF
--- a/v4/paths/AcademicSessionCollection.yaml
+++ b/v4/paths/AcademicSessionCollection.yaml
@@ -62,3 +62,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/AcademicSession.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/AcademicSessionInstance.yaml
+++ b/v4/paths/AcademicSessionInstance.yaml
@@ -30,6 +30,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/AcademicSessionExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/AcademicSessionOfferingCollection.yaml
+++ b/v4/paths/AcademicSessionOfferingCollection.yaml
@@ -100,3 +100,9 @@ get:
                     - $ref: '../schemas/ProgramOffering.yaml'
                     - $ref: '../schemas/CourseOffering.yaml'
                     - $ref: '../schemas/ComponentOffering.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/AssociationInstance.yaml
+++ b/v4/paths/AssociationInstance.yaml
@@ -30,6 +30,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/AssociationExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/BuildingCollection.yaml
+++ b/v4/paths/BuildingCollection.yaml
@@ -47,3 +47,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Building.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/BuildingInstance.yaml
+++ b/v4/paths/BuildingInstance.yaml
@@ -19,6 +19,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Building.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/BuildingRoomCollection.yaml
+++ b/v4/paths/BuildingRoomCollection.yaml
@@ -57,3 +57,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Room.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/ComponentInstance.yaml
+++ b/v4/paths/ComponentInstance.yaml
@@ -30,6 +30,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/ComponentExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/ComponentOfferingCollection.yaml
+++ b/v4/paths/ComponentOfferingCollection.yaml
@@ -87,9 +87,3 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/ComponentOffering.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/ComponentOfferingCollection.yaml
+++ b/v4/paths/ComponentOfferingCollection.yaml
@@ -87,3 +87,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/ComponentOffering.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/CourseCollection.yaml
+++ b/v4/paths/CourseCollection.yaml
@@ -61,3 +61,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Course.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/CourseComponentCollection.yaml
+++ b/v4/paths/CourseComponentCollection.yaml
@@ -60,3 +60,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Component.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/CourseComponentCollection.yaml
+++ b/v4/paths/CourseComponentCollection.yaml
@@ -60,9 +60,3 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Component.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/CourseInstance.yaml
+++ b/v4/paths/CourseInstance.yaml
@@ -31,6 +31,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/CourseExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/CourseOfferingCollection.yaml
+++ b/v4/paths/CourseOfferingCollection.yaml
@@ -93,9 +93,3 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/CourseOffering.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/CourseOfferingCollection.yaml
+++ b/v4/paths/CourseOfferingCollection.yaml
@@ -93,3 +93,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/CourseOffering.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/NewsFeedCollection.yaml
+++ b/v4/paths/NewsFeedCollection.yaml
@@ -61,3 +61,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/NewsFeed.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/NewsFeedInstance.yaml
+++ b/v4/paths/NewsFeedInstance.yaml
@@ -19,6 +19,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/NewsFeed.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/NewsFeedItemCollection.yaml
+++ b/v4/paths/NewsFeedItemCollection.yaml
@@ -66,3 +66,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/NewsItem.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/NewsFeedItemCollection.yaml
+++ b/v4/paths/NewsFeedItemCollection.yaml
@@ -66,9 +66,3 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/NewsItem.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/NewsItemInstance.yaml
+++ b/v4/paths/NewsItemInstance.yaml
@@ -19,6 +19,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/NewsItem.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/OfferingAssociationCollection.yaml
+++ b/v4/paths/OfferingAssociationCollection.yaml
@@ -92,3 +92,9 @@ get:
                           $ref: '../schemas/Person.yaml'
                         academicSession:
                           $ref: '../schemas/AcademicSession.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/OfferingAssociationCollection.yaml
+++ b/v4/paths/OfferingAssociationCollection.yaml
@@ -92,9 +92,3 @@ get:
                           $ref: '../schemas/Person.yaml'
                         academicSession:
                           $ref: '../schemas/AcademicSession.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/OfferingInstance.yaml
+++ b/v4/paths/OfferingInstance.yaml
@@ -38,6 +38,12 @@ get:
               - $ref: '../schemas/ProgramOfferingExpanded.yaml'
               - $ref: '../schemas/CourseOfferingExpanded.yaml'
               - $ref: '../schemas/ComponentOfferingExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/OrganizationCollection.yaml
+++ b/v4/paths/OrganizationCollection.yaml
@@ -53,3 +53,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Organization.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/OrganizationComponentCollection.yaml
+++ b/v4/paths/OrganizationComponentCollection.yaml
@@ -60,3 +60,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Component.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/OrganizationCourseCollection.yaml
+++ b/v4/paths/OrganizationCourseCollection.yaml
@@ -68,3 +68,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Course.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/OrganizationInstance.yaml
+++ b/v4/paths/OrganizationInstance.yaml
@@ -30,6 +30,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/OrganizationExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/OrganizationOfferingCollection.yaml
+++ b/v4/paths/OrganizationOfferingCollection.yaml
@@ -100,3 +100,9 @@ get:
                     - $ref: '../schemas/ProgramOffering.yaml'
                     - $ref: '../schemas/CourseOffering.yaml'
                     - $ref: '../schemas/ComponentOffering.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/OrganizationProgramCollection.yaml
+++ b/v4/paths/OrganizationProgramCollection.yaml
@@ -92,3 +92,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Program.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/PersonAssociationCollection.yaml
+++ b/v4/paths/PersonAssociationCollection.yaml
@@ -109,9 +109,3 @@ get:
                               $ref: '../schemas/ComponentOffering.yaml'
                             academicSession:
                               $ref: '../schemas/AcademicSession.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/PersonAssociationCollection.yaml
+++ b/v4/paths/PersonAssociationCollection.yaml
@@ -109,3 +109,9 @@ get:
                               $ref: '../schemas/ComponentOffering.yaml'
                             academicSession:
                               $ref: '../schemas/AcademicSession.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/PersonCollection.yaml
+++ b/v4/paths/PersonCollection.yaml
@@ -57,3 +57,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Person.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/PersonInstance.yaml
+++ b/v4/paths/PersonInstance.yaml
@@ -19,10 +19,15 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Person.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:
         application/problem+json:
           schema:
             $ref: '../schemas/Problem.yaml'
-

--- a/v4/paths/PersonMe.yaml
+++ b/v4/paths/PersonMe.yaml
@@ -12,6 +12,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Person.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '401':
       description: Unauthorized
       content:

--- a/v4/paths/ProgramCollection.yaml
+++ b/v4/paths/ProgramCollection.yaml
@@ -85,3 +85,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Program.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/ProgramCourseCollection.yaml
+++ b/v4/paths/ProgramCourseCollection.yaml
@@ -68,3 +68,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Course.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/ProgramCourseCollection.yaml
+++ b/v4/paths/ProgramCourseCollection.yaml
@@ -68,9 +68,3 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Course.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/ProgramInstance.yaml
+++ b/v4/paths/ProgramInstance.yaml
@@ -31,6 +31,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/ProgramExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/ProgramOfferingCollection.yaml
+++ b/v4/paths/ProgramOfferingCollection.yaml
@@ -93,9 +93,3 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/ProgramOffering.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/ProgramOfferingCollection.yaml
+++ b/v4/paths/ProgramOfferingCollection.yaml
@@ -93,3 +93,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/ProgramOffering.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/RoomCollection.yaml
+++ b/v4/paths/RoomCollection.yaml
@@ -57,3 +57,9 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Room.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/paths/RoomInstance.yaml
+++ b/v4/paths/RoomInstance.yaml
@@ -29,6 +29,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/RoomExpanded.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/Service.yaml
+++ b/v4/paths/Service.yaml
@@ -12,6 +12,12 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Service.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'
     '404':
       description: Not Found
       content:

--- a/v4/paths/Service.yaml
+++ b/v4/paths/Service.yaml
@@ -12,3 +12,9 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Service.yaml'
+    '404':
+      description: Not Found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '../schemas/Problem.yaml'

--- a/v4/spec.yaml
+++ b/v4/spec.yaml
@@ -294,8 +294,9 @@ tags:
       Error responses are formatted in the `problem+json` media type ([RFC7807](https://tools.ietf.org/html/rfc7807)):
       ```
       {
-        "code": 404,
-        "title": "Resource not found"
+        "status": 404,
+        "title": "A short, human-readable summary of the problem type, e.g. 'resource not found'."
+        "detail": "An optional human-readable explanation specific to this occurrence of the problem."
       }
       ```
   - name: Multi-lingual support


### PR DESCRIPTION
This PR is a fix for #125 and a fix for #144. Regarding #144: 404 responses for requests that return collections are removed and one missing 404 (for the service request `/`) is added. Also added 400 responses to all requests.