### PR TITLE
Makes Pagination more DRY by separating it out into its own schema file

### DIFF
--- a/v5/paths/AcademicSessionCollection.yaml
+++ b/v5/paths/AcademicSessionCollection.yaml
@@ -44,33 +44,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/AcademicSession.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/AcademicSession.yaml'

--- a/v5/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5/paths/AcademicSessionOfferingCollection.yaml
@@ -79,36 +79,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  oneOf:
-                    - $ref: '../schemas/ProgramOffering.yaml'
-                    - $ref: '../schemas/CourseOffering.yaml'
-                    - $ref: '../schemas/ComponentOffering.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      oneOf:
+                        - $ref: '../schemas/ProgramOffering.yaml'
+                        - $ref: '../schemas/CourseOffering.yaml'
+                        - $ref: '../schemas/ComponentOffering.yaml'

--- a/v5/paths/BuildingCollection.yaml
+++ b/v5/paths/BuildingCollection.yaml
@@ -29,33 +29,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Building.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Building.yaml'

--- a/v5/paths/BuildingRoomCollection.yaml
+++ b/v5/paths/BuildingRoomCollection.yaml
@@ -39,33 +39,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Room.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Room.yaml'

--- a/v5/paths/ComponentOfferingCollection.yaml
+++ b/v5/paths/ComponentOfferingCollection.yaml
@@ -69,36 +69,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/ComponentOffering.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/ComponentOffering.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/CourseCollection.yaml
+++ b/v5/paths/CourseCollection.yaml
@@ -43,21 +43,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Course.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Course.yaml'

--- a/v5/paths/CourseComponentCollection.yaml
+++ b/v5/paths/CourseComponentCollection.yaml
@@ -42,36 +42,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Component.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Component.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -75,36 +75,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/CourseOffering.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/CourseOffering.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/NewsFeedCollection.yaml
+++ b/v5/paths/NewsFeedCollection.yaml
@@ -43,33 +43,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/NewsFeed.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/NewsFeed.yaml'

--- a/v5/paths/NewsFeedItemCollection.yaml
+++ b/v5/paths/NewsFeedItemCollection.yaml
@@ -48,36 +48,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/NewsItem.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/NewsItem.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/OfferingAssociationCollection.yaml
+++ b/v5/paths/OfferingAssociationCollection.yaml
@@ -62,48 +62,28 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  allOf:
-                    - oneOf:
-                        - $ref: '../schemas/ProgramOfferingAssociation.yaml'
-                        - $ref: '../schemas/CourseOfferingAssociation.yaml'
-                        - $ref: '../schemas/ComponentOfferingAssociation.yaml'
-                    - type: object
-                      required:
-                        - person
-                      properties:
-                        person:
-                          $ref: '../schemas/Person.yaml'
-                        academicSession:
-                          $ref: '../schemas/AcademicSession.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      allOf:
+                        - oneOf:
+                            - $ref: '../schemas/ProgramOfferingAssociation.yaml'
+                            - $ref: '../schemas/CourseOfferingAssociation.yaml'
+                            - $ref: '../schemas/ComponentOfferingAssociation.yaml'
+                        - type: object
+                          required:
+                            - person
+                          properties:
+                            person:
+                              $ref: '../schemas/Person.yaml'
+                            academicSession:
+                              $ref: '../schemas/AcademicSession.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/OrganizationCollection.yaml
+++ b/v5/paths/OrganizationCollection.yaml
@@ -35,33 +35,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Organization.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Organization.yaml'

--- a/v5/paths/OrganizationComponentCollection.yaml
+++ b/v5/paths/OrganizationComponentCollection.yaml
@@ -42,33 +42,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Component.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Component.yaml'

--- a/v5/paths/OrganizationCourseCollection.yaml
+++ b/v5/paths/OrganizationCourseCollection.yaml
@@ -50,33 +50,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Course.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Course.yaml'

--- a/v5/paths/OrganizationOfferingCollection.yaml
+++ b/v5/paths/OrganizationOfferingCollection.yaml
@@ -79,36 +79,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  oneOf:
-                    - $ref: '../schemas/ProgramOffering.yaml'
-                    - $ref: '../schemas/CourseOffering.yaml'
-                    - $ref: '../schemas/ComponentOffering.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      oneOf:
+                        - $ref: '../schemas/ProgramOffering.yaml'
+                        - $ref: '../schemas/CourseOffering.yaml'
+                        - $ref: '../schemas/ComponentOffering.yaml'

--- a/v5/paths/OrganizationProgramCollection.yaml
+++ b/v5/paths/OrganizationProgramCollection.yaml
@@ -74,33 +74,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Program.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Program.yaml'

--- a/v5/paths/PersonAssociationCollection.yaml
+++ b/v5/paths/PersonAssociationCollection.yaml
@@ -61,66 +61,46 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  oneOf:
-                    - allOf:
-                        - $ref: '../schemas/ProgramOfferingAssociation.yaml'
-                        - type: object
-                          required:
-                            - offering
-                          properties:
-                            offering:
-                              $ref: '../schemas/ProgramOffering.yaml'
-                            academicSession:
-                              $ref: '../schemas/AcademicSession.yaml'
-                    - allOf:
-                        - $ref: '../schemas/CourseOfferingAssociation.yaml'
-                        - type: object
-                          required:
-                            - offering
-                          properties:
-                            offering:
-                              $ref: '../schemas/CourseOffering.yaml'
-                            academicSession:
-                              $ref: '../schemas/AcademicSession.yaml'
-                    - allOf:
-                        - $ref: '../schemas/ComponentOfferingAssociation.yaml'
-                        - type: object
-                          required:
-                            - offering
-                          properties:
-                            offering:
-                              $ref: '../schemas/ComponentOffering.yaml'
-                            academicSession:
-                              $ref: '../schemas/AcademicSession.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      oneOf:
+                        - allOf:
+                            - $ref: '../schemas/ProgramOfferingAssociation.yaml'
+                            - type: object
+                              required:
+                                - offering
+                              properties:
+                                offering:
+                                  $ref: '../schemas/ProgramOffering.yaml'
+                                academicSession:
+                                  $ref: '../schemas/AcademicSession.yaml'
+                        - allOf:
+                            - $ref: '../schemas/CourseOfferingAssociation.yaml'
+                            - type: object
+                              required:
+                                - offering
+                              properties:
+                                offering:
+                                  $ref: '../schemas/CourseOffering.yaml'
+                                academicSession:
+                                  $ref: '../schemas/AcademicSession.yaml'
+                        - allOf:
+                            - $ref: '../schemas/ComponentOfferingAssociation.yaml'
+                            - type: object
+                              required:
+                                - offering
+                              properties:
+                                offering:
+                                  $ref: '../schemas/ComponentOffering.yaml'
+                                academicSession:
+                                  $ref: '../schemas/AcademicSession.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/PersonCollection.yaml
+++ b/v5/paths/PersonCollection.yaml
@@ -39,33 +39,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Person.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Person.yaml'

--- a/v5/paths/ProgramCollection.yaml
+++ b/v5/paths/ProgramCollection.yaml
@@ -67,33 +67,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Program.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Program.yaml'

--- a/v5/paths/ProgramCourseCollection.yaml
+++ b/v5/paths/ProgramCourseCollection.yaml
@@ -50,36 +50,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Course.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Course.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/ProgramOfferingCollection.yaml
+++ b/v5/paths/ProgramOfferingCollection.yaml
@@ -75,36 +75,16 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/ProgramOffering.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/ProgramOffering.yaml'
     '404':
       description: Not Found
       content:

--- a/v5/paths/RoomCollection.yaml
+++ b/v5/paths/RoomCollection.yaml
@@ -39,33 +39,13 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - pageSize
-              - pageNumber
-              - hasPreviousPage
-              - hasNextPage
-              - items
-            properties:
-              pageSize:
-                type: integer
-                format: int32
-                description: The number of items per page
-              pageNumber:
-                type: integer
-                format: int32
-                description: The current page number
-              hasPreviousPage:
-                type: boolean
-                description: Whether there is a previous page
-              hasNextPage:
-                type: boolean
-                description: Whether there is a previous page
-              totalPages:
-                type: integer
-                format: int32
-                description: Total number of pages
-              items:
-                type: array
-                items:
-                  $ref: '../schemas/Room.yaml'
+            allOf:
+              - $ref: '../schemas/Pagination.yaml'
+              - type: object
+                required:
+                  - items
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '../schemas/Room.yaml'

--- a/v5/schemas/Pagination.yaml
+++ b/v5/schemas/Pagination.yaml
@@ -1,0 +1,26 @@
+type: object
+required:
+  - pageSize
+  - pageNumber
+  - hasPreviousPage
+  - hasNextPage
+  - items
+properties:
+  pageSize:
+    type: integer
+    format: int32
+    description: The number of items per page
+  pageNumber:
+    type: integer
+    format: int32
+    description: The current page number
+  hasPreviousPage:
+    type: boolean
+    description: Whether there is a previous page
+  hasNextPage:
+    type: boolean
+    description: Whether there is a previous page
+  totalPages:
+    type: integer
+    format: int32
+    description: Total number of pages


### PR DESCRIPTION
This PR eliminates a lot of duplication by moving pagination details for collection responses to its own schema file.

@hamrt this PR changes nothing about how pagination works since @arthurvanalten PR's, but only restructures the files. Could you take a quick look to check If I've missed nothing?