### PR TITLE
Improve error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved explanation on Markdown
 - ext objects to all collection endpoints
 - #158 Improve error responses to make them more semantically correct
+- Added descriptions for HTTP error responses: 400, 401, 403, 404, 405, 429 and 500. Fixes #125 and #144.
 
 ### Changed
 - rename of changed.md file on version level to release file on version level to provide for additional release information fo future releases
 - Changed pagination for all responses returning a collection of items. Responses now include `hasNextPage`, `hasPreviousPage` and optional `totalPages` attributes. These additions make pagination easier for clients.
+- Removed 404 responses for paths that return a collection.
 
 ## [4.0.0] - 2019-09-01
 ### Added

--- a/v5/paths/AcademicSessionCollection.yaml
+++ b/v5/paths/AcademicSessionCollection.yaml
@@ -74,3 +74,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/AcademicSession.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/AcademicSessionCollection.yaml
+++ b/v5/paths/AcademicSessionCollection.yaml
@@ -75,7 +75,7 @@ get:
                 items:
                   $ref: '../schemas/AcademicSession.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -85,4 +85,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/AcademicSessionCollection.yaml
+++ b/v5/paths/AcademicSessionCollection.yaml
@@ -81,7 +81,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/AcademicSessionInstance.yaml
+++ b/v5/paths/AcademicSessionInstance.yaml
@@ -31,7 +31,7 @@ get:
           schema:
             $ref: '../schemas/AcademicSessionExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -43,4 +43,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/AcademicSessionInstance.yaml
+++ b/v5/paths/AcademicSessionInstance.yaml
@@ -39,7 +39,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/AcademicSessionInstance.yaml
+++ b/v5/paths/AcademicSessionInstance.yaml
@@ -30,9 +30,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/AcademicSessionExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5/paths/AcademicSessionOfferingCollection.yaml
@@ -113,7 +113,7 @@ get:
                     - $ref: '../schemas/CourseOffering.yaml'
                     - $ref: '../schemas/ComponentOffering.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -123,4 +123,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5/paths/AcademicSessionOfferingCollection.yaml
@@ -112,3 +112,15 @@ get:
                     - $ref: '../schemas/ProgramOffering.yaml'
                     - $ref: '../schemas/CourseOffering.yaml'
                     - $ref: '../schemas/ComponentOffering.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5/paths/AcademicSessionOfferingCollection.yaml
@@ -119,7 +119,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/AssociationInstance.yaml
+++ b/v5/paths/AssociationInstance.yaml
@@ -39,7 +39,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/AssociationInstance.yaml
+++ b/v5/paths/AssociationInstance.yaml
@@ -31,7 +31,7 @@ get:
           schema:
             $ref: '../schemas/AssociationExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -43,4 +43,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/AssociationInstance.yaml
+++ b/v5/paths/AssociationInstance.yaml
@@ -30,9 +30,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/AssociationExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/BuildingCollection.yaml
+++ b/v5/paths/BuildingCollection.yaml
@@ -60,7 +60,7 @@ get:
                 items:
                   $ref: '../schemas/Building.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -70,4 +70,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/BuildingCollection.yaml
+++ b/v5/paths/BuildingCollection.yaml
@@ -66,7 +66,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/BuildingCollection.yaml
+++ b/v5/paths/BuildingCollection.yaml
@@ -59,3 +59,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Building.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/BuildingInstance.yaml
+++ b/v5/paths/BuildingInstance.yaml
@@ -19,9 +19,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Building.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/BuildingInstance.yaml
+++ b/v5/paths/BuildingInstance.yaml
@@ -20,7 +20,7 @@ get:
           schema:
             $ref: '../schemas/Building.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -32,4 +32,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/BuildingInstance.yaml
+++ b/v5/paths/BuildingInstance.yaml
@@ -28,7 +28,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/BuildingRoomCollection.yaml
+++ b/v5/paths/BuildingRoomCollection.yaml
@@ -70,7 +70,7 @@ get:
                 items:
                   $ref: '../schemas/Room.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -80,4 +80,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/BuildingRoomCollection.yaml
+++ b/v5/paths/BuildingRoomCollection.yaml
@@ -69,3 +69,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Room.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/BuildingRoomCollection.yaml
+++ b/v5/paths/BuildingRoomCollection.yaml
@@ -76,7 +76,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ComponentInstance.yaml
+++ b/v5/paths/ComponentInstance.yaml
@@ -31,7 +31,7 @@ get:
           schema:
             $ref: '../schemas/ComponentExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -43,4 +43,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/ComponentInstance.yaml
+++ b/v5/paths/ComponentInstance.yaml
@@ -39,7 +39,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ComponentInstance.yaml
+++ b/v5/paths/ComponentInstance.yaml
@@ -30,9 +30,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/ComponentExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/ComponentOfferingCollection.yaml
+++ b/v5/paths/ComponentOfferingCollection.yaml
@@ -106,7 +106,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ComponentOfferingCollection.yaml
+++ b/v5/paths/ComponentOfferingCollection.yaml
@@ -99,9 +99,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/ComponentOffering.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/ComponentOfferingCollection.yaml
+++ b/v5/paths/ComponentOfferingCollection.yaml
@@ -100,7 +100,7 @@ get:
                 items:
                   $ref: '../schemas/ComponentOffering.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -110,4 +110,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/CourseCollection.yaml
+++ b/v5/paths/CourseCollection.yaml
@@ -68,7 +68,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/CourseCollection.yaml
+++ b/v5/paths/CourseCollection.yaml
@@ -62,7 +62,7 @@ get:
                 items:
                   $ref: '../schemas/Course.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -72,4 +72,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/CourseCollection.yaml
+++ b/v5/paths/CourseCollection.yaml
@@ -61,3 +61,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Course.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/CourseComponentCollection.yaml
+++ b/v5/paths/CourseComponentCollection.yaml
@@ -72,9 +72,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Component.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/CourseComponentCollection.yaml
+++ b/v5/paths/CourseComponentCollection.yaml
@@ -73,7 +73,7 @@ get:
                 items:
                   $ref: '../schemas/Component.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -83,4 +83,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/CourseComponentCollection.yaml
+++ b/v5/paths/CourseComponentCollection.yaml
@@ -79,7 +79,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/CourseInstance.yaml
+++ b/v5/paths/CourseInstance.yaml
@@ -31,9 +31,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/CourseExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/CourseInstance.yaml
+++ b/v5/paths/CourseInstance.yaml
@@ -40,7 +40,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/CourseInstance.yaml
+++ b/v5/paths/CourseInstance.yaml
@@ -32,7 +32,7 @@ get:
           schema:
             $ref: '../schemas/CourseExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -44,4 +44,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -106,7 +106,7 @@ get:
                 items:
                   $ref: '../schemas/CourseOffering.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -116,4 +116,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -112,7 +112,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -105,9 +105,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/CourseOffering.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/NewsFeedCollection.yaml
+++ b/v5/paths/NewsFeedCollection.yaml
@@ -74,7 +74,7 @@ get:
                 items:
                   $ref: '../schemas/NewsFeed.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -84,4 +84,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/NewsFeedCollection.yaml
+++ b/v5/paths/NewsFeedCollection.yaml
@@ -73,3 +73,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/NewsFeed.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/NewsFeedCollection.yaml
+++ b/v5/paths/NewsFeedCollection.yaml
@@ -80,7 +80,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/NewsFeedInstance.yaml
+++ b/v5/paths/NewsFeedInstance.yaml
@@ -19,9 +19,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/NewsFeed.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/NewsFeedInstance.yaml
+++ b/v5/paths/NewsFeedInstance.yaml
@@ -28,7 +28,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/NewsFeedInstance.yaml
+++ b/v5/paths/NewsFeedInstance.yaml
@@ -20,7 +20,7 @@ get:
           schema:
             $ref: '../schemas/NewsFeed.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -32,4 +32,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/NewsFeedItemCollection.yaml
+++ b/v5/paths/NewsFeedItemCollection.yaml
@@ -79,7 +79,7 @@ get:
                 items:
                   $ref: '../schemas/NewsItem.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -89,4 +89,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/NewsFeedItemCollection.yaml
+++ b/v5/paths/NewsFeedItemCollection.yaml
@@ -78,9 +78,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/NewsItem.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/NewsFeedItemCollection.yaml
+++ b/v5/paths/NewsFeedItemCollection.yaml
@@ -85,7 +85,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/NewsItemInstance.yaml
+++ b/v5/paths/NewsItemInstance.yaml
@@ -19,9 +19,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/NewsItem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/NewsItemInstance.yaml
+++ b/v5/paths/NewsItemInstance.yaml
@@ -20,7 +20,7 @@ get:
           schema:
             $ref: '../schemas/NewsItem.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -32,4 +32,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/NewsItemInstance.yaml
+++ b/v5/paths/NewsItemInstance.yaml
@@ -28,7 +28,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OfferingAssociationCollection.yaml
+++ b/v5/paths/OfferingAssociationCollection.yaml
@@ -104,9 +104,15 @@ get:
                           $ref: '../schemas/Person.yaml'
                         academicSession:
                           $ref: '../schemas/AcademicSession.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/OfferingAssociationCollection.yaml
+++ b/v5/paths/OfferingAssociationCollection.yaml
@@ -105,7 +105,7 @@ get:
                         academicSession:
                           $ref: '../schemas/AcademicSession.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -115,4 +115,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/OfferingAssociationCollection.yaml
+++ b/v5/paths/OfferingAssociationCollection.yaml
@@ -111,7 +111,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OfferingInstance.yaml
+++ b/v5/paths/OfferingInstance.yaml
@@ -38,9 +38,17 @@ get:
               - $ref: '../schemas/ProgramOfferingExpanded.yaml'
               - $ref: '../schemas/CourseOfferingExpanded.yaml'
               - $ref: '../schemas/ComponentOfferingExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/OfferingInstance.yaml
+++ b/v5/paths/OfferingInstance.yaml
@@ -47,7 +47,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OfferingInstance.yaml
+++ b/v5/paths/OfferingInstance.yaml
@@ -39,7 +39,7 @@ get:
               - $ref: '../schemas/CourseOfferingExpanded.yaml'
               - $ref: '../schemas/ComponentOfferingExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -51,4 +51,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/OrganizationCollection.yaml
+++ b/v5/paths/OrganizationCollection.yaml
@@ -65,3 +65,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Organization.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/OrganizationCollection.yaml
+++ b/v5/paths/OrganizationCollection.yaml
@@ -66,7 +66,7 @@ get:
                 items:
                   $ref: '../schemas/Organization.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -76,4 +76,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/OrganizationCollection.yaml
+++ b/v5/paths/OrganizationCollection.yaml
@@ -72,7 +72,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OrganizationComponentCollection.yaml
+++ b/v5/paths/OrganizationComponentCollection.yaml
@@ -72,3 +72,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Component.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/OrganizationComponentCollection.yaml
+++ b/v5/paths/OrganizationComponentCollection.yaml
@@ -73,7 +73,7 @@ get:
                 items:
                   $ref: '../schemas/Component.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -83,4 +83,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/OrganizationComponentCollection.yaml
+++ b/v5/paths/OrganizationComponentCollection.yaml
@@ -79,7 +79,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OrganizationCourseCollection.yaml
+++ b/v5/paths/OrganizationCourseCollection.yaml
@@ -87,7 +87,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OrganizationCourseCollection.yaml
+++ b/v5/paths/OrganizationCourseCollection.yaml
@@ -81,7 +81,7 @@ get:
                 items:
                   $ref: '../schemas/Course.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -91,5 +91,5 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'
 

--- a/v5/paths/OrganizationCourseCollection.yaml
+++ b/v5/paths/OrganizationCourseCollection.yaml
@@ -80,3 +80,16 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Course.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'
+

--- a/v5/paths/OrganizationInstance.yaml
+++ b/v5/paths/OrganizationInstance.yaml
@@ -31,7 +31,7 @@ get:
           schema:
             $ref: '../schemas/OrganizationExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -43,4 +43,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/OrganizationInstance.yaml
+++ b/v5/paths/OrganizationInstance.yaml
@@ -39,7 +39,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OrganizationInstance.yaml
+++ b/v5/paths/OrganizationInstance.yaml
@@ -30,9 +30,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/OrganizationExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/OrganizationOfferingCollection.yaml
+++ b/v5/paths/OrganizationOfferingCollection.yaml
@@ -113,7 +113,7 @@ get:
                     - $ref: '../schemas/CourseOffering.yaml'
                     - $ref: '../schemas/ComponentOffering.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -123,4 +123,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/OrganizationOfferingCollection.yaml
+++ b/v5/paths/OrganizationOfferingCollection.yaml
@@ -112,3 +112,15 @@ get:
                     - $ref: '../schemas/ProgramOffering.yaml'
                     - $ref: '../schemas/CourseOffering.yaml'
                     - $ref: '../schemas/ComponentOffering.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/OrganizationOfferingCollection.yaml
+++ b/v5/paths/OrganizationOfferingCollection.yaml
@@ -119,7 +119,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OrganizationProgramCollection.yaml
+++ b/v5/paths/OrganizationProgramCollection.yaml
@@ -111,7 +111,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/OrganizationProgramCollection.yaml
+++ b/v5/paths/OrganizationProgramCollection.yaml
@@ -104,3 +104,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Program.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/OrganizationProgramCollection.yaml
+++ b/v5/paths/OrganizationProgramCollection.yaml
@@ -105,7 +105,7 @@ get:
                 items:
                   $ref: '../schemas/Program.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -115,4 +115,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/PersonAssociationCollection.yaml
+++ b/v5/paths/PersonAssociationCollection.yaml
@@ -121,9 +121,15 @@ get:
                               $ref: '../schemas/ComponentOffering.yaml'
                             academicSession:
                               $ref: '../schemas/AcademicSession.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/PersonAssociationCollection.yaml
+++ b/v5/paths/PersonAssociationCollection.yaml
@@ -128,7 +128,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/PersonAssociationCollection.yaml
+++ b/v5/paths/PersonAssociationCollection.yaml
@@ -122,7 +122,7 @@ get:
                             academicSession:
                               $ref: '../schemas/AcademicSession.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -132,4 +132,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/PersonCollection.yaml
+++ b/v5/paths/PersonCollection.yaml
@@ -70,7 +70,7 @@ get:
                 items:
                   $ref: '../schemas/Person.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -80,4 +80,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/PersonCollection.yaml
+++ b/v5/paths/PersonCollection.yaml
@@ -76,7 +76,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/PersonCollection.yaml
+++ b/v5/paths/PersonCollection.yaml
@@ -69,3 +69,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Person.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/PersonInstance.yaml
+++ b/v5/paths/PersonInstance.yaml
@@ -19,10 +19,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Person.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
-
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/PersonInstance.yaml
+++ b/v5/paths/PersonInstance.yaml
@@ -20,7 +20,7 @@ get:
           schema:
             $ref: '../schemas/Person.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -32,4 +32,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/PersonInstance.yaml
+++ b/v5/paths/PersonInstance.yaml
@@ -28,7 +28,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/PersonMe.yaml
+++ b/v5/paths/PersonMe.yaml
@@ -13,7 +13,7 @@ get:
           schema:
             $ref: '../schemas/Person.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -25,4 +25,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/PersonMe.yaml
+++ b/v5/paths/PersonMe.yaml
@@ -12,15 +12,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Person.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
     '401':
-      description: Unauthorized
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/PersonMe.yaml
+++ b/v5/paths/PersonMe.yaml
@@ -21,7 +21,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ProgramCollection.yaml
+++ b/v5/paths/ProgramCollection.yaml
@@ -98,7 +98,7 @@ get:
                 items:
                   $ref: '../schemas/Program.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -108,4 +108,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/ProgramCollection.yaml
+++ b/v5/paths/ProgramCollection.yaml
@@ -104,7 +104,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ProgramCollection.yaml
+++ b/v5/paths/ProgramCollection.yaml
@@ -97,3 +97,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Program.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/ProgramCourseCollection.yaml
+++ b/v5/paths/ProgramCourseCollection.yaml
@@ -87,7 +87,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ProgramCourseCollection.yaml
+++ b/v5/paths/ProgramCourseCollection.yaml
@@ -80,9 +80,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Course.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/ProgramCourseCollection.yaml
+++ b/v5/paths/ProgramCourseCollection.yaml
@@ -81,7 +81,7 @@ get:
                 items:
                   $ref: '../schemas/Course.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -91,4 +91,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/ProgramInstance.yaml
+++ b/v5/paths/ProgramInstance.yaml
@@ -31,9 +31,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/ProgramExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/ProgramInstance.yaml
+++ b/v5/paths/ProgramInstance.yaml
@@ -40,7 +40,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ProgramInstance.yaml
+++ b/v5/paths/ProgramInstance.yaml
@@ -32,7 +32,7 @@ get:
           schema:
             $ref: '../schemas/ProgramExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -44,4 +44,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/ProgramOfferingCollection.yaml
+++ b/v5/paths/ProgramOfferingCollection.yaml
@@ -106,7 +106,7 @@ get:
                 items:
                   $ref: '../schemas/ProgramOffering.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -116,4 +116,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/ProgramOfferingCollection.yaml
+++ b/v5/paths/ProgramOfferingCollection.yaml
@@ -112,7 +112,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/ProgramOfferingCollection.yaml
+++ b/v5/paths/ProgramOfferingCollection.yaml
@@ -105,9 +105,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/ProgramOffering.yaml'
-    '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/RoomCollection.yaml
+++ b/v5/paths/RoomCollection.yaml
@@ -70,7 +70,7 @@ get:
                 items:
                   $ref: '../schemas/Room.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -80,4 +80,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/RoomCollection.yaml
+++ b/v5/paths/RoomCollection.yaml
@@ -69,3 +69,15 @@ get:
                 type: array
                 items:
                   $ref: '../schemas/Room.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/RoomCollection.yaml
+++ b/v5/paths/RoomCollection.yaml
@@ -76,7 +76,7 @@ get:
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/RoomInstance.yaml
+++ b/v5/paths/RoomInstance.yaml
@@ -29,9 +29,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/RoomExpanded.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
     '404':
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            $ref: '../schemas/Problem.yaml'
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/paths/RoomInstance.yaml
+++ b/v5/paths/RoomInstance.yaml
@@ -38,7 +38,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/RoomInstance.yaml
+++ b/v5/paths/RoomInstance.yaml
@@ -30,7 +30,7 @@ get:
           schema:
             $ref: '../schemas/RoomExpanded.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -42,4 +42,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/Service.yaml
+++ b/v5/paths/Service.yaml
@@ -21,7 +21,7 @@ get:
     '404':
       $ref: '../schemas/ErrorNotFound.yaml'
     '405':
-      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+      $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':

--- a/v5/paths/Service.yaml
+++ b/v5/paths/Service.yaml
@@ -13,7 +13,7 @@ get:
           schema:
             $ref: '../schemas/Service.yaml'
     '400':
-      $ref: '../schemas/ErrorInvalidRequest.yaml'
+      $ref: '../schemas/ErrorBadRequest.yaml'
     '401':
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
@@ -25,4 +25,4 @@ get:
     '429':
       $ref: '../schemas/ErrorTooManyRequests.yaml'
     '500':
-      $ref: '../schemas/ErrorFatalError.yaml'
+      $ref: '../schemas/ErrorInternalServerError.yaml'

--- a/v5/paths/Service.yaml
+++ b/v5/paths/Service.yaml
@@ -12,3 +12,17 @@ get:
         application/json:
           schema:
             $ref: '../schemas/Service.yaml'
+    '400':
+      $ref: '../schemas/ErrorInvalidRequest.yaml'
+    '401':
+      $ref: '../schemas/ErrorUnauthorized.yaml'
+    '403':
+      $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
+    '405':
+      $ref: '../schemas/ErrorMethodNotImplemented.yaml'
+    '429':
+      $ref: '../schemas/ErrorTooManyRequests.yaml'
+    '500':
+      $ref: '../schemas/ErrorFatalError.yaml'

--- a/v5/schemas/ErrorBadRequest.yaml
+++ b/v5/schemas/ErrorBadRequest.yaml
@@ -1,4 +1,4 @@
-description: Fatal error
+description: Bad request
 content:
   application/problem+json:
     schema:

--- a/v5/schemas/ErrorFatalError.yaml
+++ b/v5/schemas/ErrorFatalError.yaml
@@ -1,0 +1,5 @@
+description: Fatal error
+content:
+  application/problem+json:
+    schema:
+      $ref: 'Problem.yaml'

--- a/v5/schemas/ErrorForbidden.yaml
+++ b/v5/schemas/ErrorForbidden.yaml
@@ -1,0 +1,5 @@
+description: Forbidden
+content:
+  application/problem+json:
+    schema:
+      $ref: 'Problem.yaml'

--- a/v5/schemas/ErrorInternalServerError.yaml
+++ b/v5/schemas/ErrorInternalServerError.yaml
@@ -1,4 +1,4 @@
-description: Invalid request
+description: Internal Server Error
 content:
   application/problem+json:
     schema:

--- a/v5/schemas/ErrorInvalidRequest.yaml
+++ b/v5/schemas/ErrorInvalidRequest.yaml
@@ -1,0 +1,5 @@
+description: Invalid request
+content:
+  application/problem+json:
+    schema:
+      $ref: 'Problem.yaml'

--- a/v5/schemas/ErrorMethodNotAllowed.yaml
+++ b/v5/schemas/ErrorMethodNotAllowed.yaml
@@ -1,4 +1,4 @@
-description: Method not implemented
+description: Method not allowed
 content:
   application/problem+json:
     schema:

--- a/v5/schemas/ErrorMethodNotImplemented.yaml
+++ b/v5/schemas/ErrorMethodNotImplemented.yaml
@@ -1,0 +1,5 @@
+description: Method not implemented
+content:
+  application/problem+json:
+    schema:
+      $ref: 'Problem.yaml'

--- a/v5/schemas/ErrorNotFound.yaml
+++ b/v5/schemas/ErrorNotFound.yaml
@@ -1,0 +1,5 @@
+description: Not Found
+content:
+  application/problem+json:
+    schema:
+      $ref: 'Problem.yaml'

--- a/v5/schemas/ErrorTooManyRequests.yaml
+++ b/v5/schemas/ErrorTooManyRequests.yaml
@@ -1,0 +1,5 @@
+description: Too many requests
+content:
+  application/problem+json:
+    schema:
+      $ref: 'Problem.yaml'

--- a/v5/schemas/ErrorUnauthorized.yaml
+++ b/v5/schemas/ErrorUnauthorized.yaml
@@ -1,0 +1,5 @@
+description: Unauthorized
+content:
+  application/problem+json:
+    schema:
+      $ref: 'Problem.yaml'

--- a/v5/spec.yaml
+++ b/v5/spec.yaml
@@ -294,8 +294,9 @@ tags:
       Error responses are formatted in the `problem+json` media type ([RFC7807](https://tools.ietf.org/html/rfc7807)):
       ```
       {
-        "code": 404,
-        "title": "Resource not found"
+        "status": 404,
+        "title": "Resource not found",
+        "detail": "The resource with id 00000000-0000-0000-0000-000000000000 could not be found."
       }
       ```
   - name: Multi-lingual support


### PR DESCRIPTION
This PR improves all error responses and fixes incorrect documentation. It fixes both #125 and #144:

The following error responses have been added to all requests:
- `400`
- `401`
- `403`
- `405`
- `429`
- `500`

And `404` to all requests returning a single response 