### PR TITLE
Change organization types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - rename of changed.md file on version level to release file on version level to provide for additional release information fo future releases
 - Changed pagination for all responses returning a collection of items. Responses now include `hasNextPage`, `hasPreviousPage` and optional `totalPages` attributes. These additions make pagination easier for clients.
+- Changed the enumeration for organizationTypes. Renamed `institution` to `institute` to prevent confusion with `root`. Added `branch`, `academy` and `school`.
 
 ## [4.0.0] - 2019-09-01
 ### Added

--- a/v5/enumerations/organizationType.yaml
+++ b/v5/enumerations/organizationType.yaml
@@ -1,5 +1,13 @@
 type: string
-description: The type of this organization. Each OOAPI endpoint should have a single organization with type `root`, describing the root organization.
+description: |
+  The type of this organization. Each OOAPI endpoint should have a single organization with type `root`, describing the root organization.
+  - root: the root of this organization, representing the Educational Institution itself
+  - institute: instituut
+  - department: departement
+  - faculty: faculteit
+  - branch: vestiging
+  - academy: academie
+  - school: school
 enum:
   - root
   - institute

--- a/v5/enumerations/organizationType.yaml
+++ b/v5/enumerations/organizationType.yaml
@@ -1,8 +1,11 @@
 type: string
-description: The type of this organization
+description: The type of this organization. Each OOAPI endpoint should have a single organization with type `root`, describing the root organization.
 enum:
   - root
-  - institution
+  - institute
   - department
   - faculty
+  - branch
+  - academy
+  - school
 example: root


### PR DESCRIPTION
This PR fixes #145:

It changes the enumeration for `organizationTypes`. Renamed `institution` to `institute` to prevent confusion with `root`. Added `branch`, `academy` and `school`.