### PR TITLE
Add billing addrestype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - rename of changed.md file on version level to release file on version level to provide for additional release information fo future releases
 - Changed pagination for all responses returning a collection of items. Responses now include `hasNextPage`, `hasPreviousPage` and optional `totalPages` attributes. These additions make pagination easier for clients.
+- Changed postalType enumeration. Added `billing` address type
 
 ## [4.0.0] - 2019-09-01
 ### Added

--- a/v5/enumerations/postalType.yaml
+++ b/v5/enumerations/postalType.yaml
@@ -4,7 +4,9 @@ description: |
   - postal: post
   - visit: bezoek
   - deliveries: bezorg
+  - billing: factuur
 enum:
   - postal
   - visit
   - deliveries
+  - billing


### PR DESCRIPTION
This PR fixes #153 by adding `billing` as a new adress type to the PostalType enumeration list.