### PR TITLE
Add `mainLanguage` to Programs, Courses and Programs and rename to `teachingLanguage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - rename of changed.md file on version level to release file on version level to provide for additional release information fo future releases
 - Changed pagination for all responses returning a collection of items. Responses now include `hasNextPage`, `hasPreviousPage` and optional `totalPages` attributes. These additions make pagination easier for clients.
+- Renames the offering attribute`mainLanguage` to `teachingLanguage` and also adds it to all Programs, Courses and Components.
 
 ## [4.0.0] - 2019-09-01
 ### Added

--- a/v5/parameters/mainLanguage.yaml
+++ b/v5/parameters/mainLanguage.yaml
@@ -1,0 +1,6 @@
+name: mainLanguage
+in: query
+description: Filter by mainLanguage, which is a a string describing the language, formatted according to RFC3339.
+required: false
+schema:
+  type: string

--- a/v5/parameters/mainLanguage.yaml
+++ b/v5/parameters/mainLanguage.yaml
@@ -1,6 +1,0 @@
-name: mainLanguage
-in: query
-description: Filter by mainLanguage, which is a a string describing the language, formatted according to RFC3339.
-required: false
-schema:
-  type: string

--- a/v5/parameters/teachingLanguage.yaml
+++ b/v5/parameters/teachingLanguage.yaml
@@ -1,0 +1,6 @@
+name: teachingLanguage
+in: query
+description: Filter by teachingLanguage, which is a string describing the main teaching language, formatted according to RFC3339.
+required: false
+schema:
+  type: string

--- a/v5/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5/paths/AcademicSessionOfferingCollection.yaml
@@ -25,15 +25,6 @@ get:
           - program
           - course
           - component
-    - name: mainLanguage
-      in: query
-      description: Filter by mainLanguage
-      required: false
-      schema:
-        type: string
-        enum:
-          - nl-nl
-          - en-gb
     - name: isLineItem
       in: query
       description: Filter by isLineItem

--- a/v5/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5/paths/AcademicSessionOfferingCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: type
       in: query
       description: Filter by offering type

--- a/v5/paths/ComponentOfferingCollection.yaml
+++ b/v5/paths/ComponentOfferingCollection.yaml
@@ -15,15 +15,6 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - name: mainLanguage
-      in: query
-      description: Filter by mainLanguage
-      required: false
-      schema:
-        type: string
-        enum:
-          - nl-nl
-          - en-gb
     - name: isLineItem
       in: query
       description: Filter by isLineItem

--- a/v5/paths/ComponentOfferingCollection.yaml
+++ b/v5/paths/ComponentOfferingCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: isLineItem
       in: query
       description: Filter by isLineItem

--- a/v5/paths/CourseCollection.yaml
+++ b/v5/paths/CourseCollection.yaml
@@ -8,6 +8,7 @@ get:
     - $ref: '../parameters/pageSize.yaml'
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
+    - $ref: '../parameters/mainLanguage.yaml'
     - name: level
       in: query
       description: Filter by level

--- a/v5/paths/CourseCollection.yaml
+++ b/v5/paths/CourseCollection.yaml
@@ -8,7 +8,7 @@ get:
     - $ref: '../parameters/pageSize.yaml'
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
-    - $ref: '../parameters/mainLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: level
       in: query
       description: Filter by level

--- a/v5/paths/CourseComponentCollection.yaml
+++ b/v5/paths/CourseComponentCollection.yaml
@@ -15,7 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - $ref: '../parameters/mainLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: type
       in: query
       description: Filter by component type

--- a/v5/paths/CourseComponentCollection.yaml
+++ b/v5/paths/CourseComponentCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/mainLanguage.yaml'
     - name: type
       in: query
       description: Filter by component type

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -15,15 +15,6 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - name: mainLanguage
-      in: query
-      description: Filter by mainLanguage
-      required: false
-      schema:
-        type: string
-        enum:
-          - nl-nl
-          - en-gb
     - name: modeOfStudy
       in: query
       description: Filter by modeOfStudy

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: modeOfStudy
       in: query
       description: Filter by modeOfStudy

--- a/v5/paths/OrganizationComponentCollection.yaml
+++ b/v5/paths/OrganizationComponentCollection.yaml
@@ -15,7 +15,7 @@ get:
     - $ref: '../parameters/pageSize.yaml'
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
-    - $ref: '../parameters/mainLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: type
       in: query
       description: Filter by component type

--- a/v5/paths/OrganizationComponentCollection.yaml
+++ b/v5/paths/OrganizationComponentCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageSize.yaml'
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
+    - $ref: '../parameters/mainLanguage.yaml'
     - name: type
       in: query
       description: Filter by component type

--- a/v5/paths/OrganizationCourseCollection.yaml
+++ b/v5/paths/OrganizationCourseCollection.yaml
@@ -15,7 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - $ref: '../parameters/mainLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: level
       in: query
       description: Filter by level

--- a/v5/paths/OrganizationCourseCollection.yaml
+++ b/v5/paths/OrganizationCourseCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/mainLanguage.yaml'
     - name: level
       in: query
       description: Filter by level

--- a/v5/paths/OrganizationOfferingCollection.yaml
+++ b/v5/paths/OrganizationOfferingCollection.yaml
@@ -25,15 +25,6 @@ get:
           - program
           - course
           - component
-    - name: mainLanguage
-      in: query
-      description: Filter by mainLanguage
-      required: false
-      schema:
-        type: string
-        enum:
-          - nl-nl
-          - en-gb
     - name: isLineItem
       in: query
       description: Filter by isLineItem

--- a/v5/paths/OrganizationOfferingCollection.yaml
+++ b/v5/paths/OrganizationOfferingCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: type
       in: query
       description: Filter by offering type

--- a/v5/paths/OrganizationProgramCollection.yaml
+++ b/v5/paths/OrganizationProgramCollection.yaml
@@ -15,7 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - $ref: '../parameters/mainLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: type
       in: query
       description: Filter by program type

--- a/v5/paths/OrganizationProgramCollection.yaml
+++ b/v5/paths/OrganizationProgramCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/mainLanguage.yaml'
     - name: type
       in: query
       description: Filter by program type

--- a/v5/paths/ProgramCollection.yaml
+++ b/v5/paths/ProgramCollection.yaml
@@ -8,6 +8,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/mainLanguage.yaml'
     - name: type
       in: query
       description: Filter by program type

--- a/v5/paths/ProgramCollection.yaml
+++ b/v5/paths/ProgramCollection.yaml
@@ -8,7 +8,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - $ref: '../parameters/mainLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: type
       in: query
       description: Filter by program type

--- a/v5/paths/ProgramCourseCollection.yaml
+++ b/v5/paths/ProgramCourseCollection.yaml
@@ -15,7 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - $ref: '../parameters/mainLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: level
       in: query
       description: Filter by level

--- a/v5/paths/ProgramCourseCollection.yaml
+++ b/v5/paths/ProgramCourseCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/mainLanguage.yaml'
     - name: level
       in: query
       description: Filter by level

--- a/v5/paths/ProgramOfferingCollection.yaml
+++ b/v5/paths/ProgramOfferingCollection.yaml
@@ -15,15 +15,6 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
-    - name: mainLanguage
-      in: query
-      description: Filter by mainLanguage
-      required: false
-      schema:
-        type: string
-        enum:
-          - nl-nl
-          - en-gb
     - name: modeOfStudy
       in: query
       description: Filter by modeOfStudy

--- a/v5/paths/ProgramOfferingCollection.yaml
+++ b/v5/paths/ProgramOfferingCollection.yaml
@@ -15,6 +15,7 @@ get:
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/acceptLanguage.yaml'
+    - $ref: '../parameters/teachingLanguage.yaml'
     - name: modeOfStudy
       in: query
       description: Filter by modeOfStudy

--- a/v5/schemas/Component.yaml
+++ b/v5/schemas/Component.yaml
@@ -4,6 +4,7 @@ required:
   - componentId
   - type
   - name
+  - mainLanguage
   - abbreviation
 properties:
   componentId:
@@ -43,5 +44,9 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
+  mainLanguage:
+    type: string
+    description: The main language in which this component is given. A string formatted according to RFC3066.
+    example: nl-NL
   ext:
     $ref: './Ext.yaml'

--- a/v5/schemas/Component.yaml
+++ b/v5/schemas/Component.yaml
@@ -44,9 +44,9 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
-  mainLanguage:
+  teachingLanguage:
     type: string
-    description: The main language in which this component is given. A string formatted according to RFC3066.
+    description: The teaching language in which this component is given. A string formatted according to RFC3066.
     example: nl-NL
   ext:
     $ref: './Ext.yaml'

--- a/v5/schemas/Course.yaml
+++ b/v5/schemas/Course.yaml
@@ -5,6 +5,7 @@ required:
   - name
   - abbreviation
   - description
+  - mainLanguage
   - level
 properties:
   courseId:
@@ -31,6 +32,10 @@ properties:
     type: string
     description: The description of this course (ECTS-description). [Our internal Markdown syntax](#tag/formatting-and-displaying-results-from-API) MAY be used for rich text representation.
     example: 'As with all empirical sciences, to assure valid outcomes, HCI studies heavily rely on research methods and statistics. This holds for the design of user interfaces, personalized recommender systems, and interaction paradigms for the internet of things. This course prepares you to do so by learning you to collect data, design experiments, and analyze the results. By the end of the course, you will have a detailed understanding of how to select and apply quantitative research methods and analysis to address virtually all HCI challenges. Quantitative research and data analysis will be taught in the context of state-of-the-art HCI challenges. Lectures will be alternated with hands-on learning, including work with predefined datasets (e.g., addressing facial features, cognitive load, and emotion). Additionally, students will set up their own research (e.g., using eye tracking). Data processing and analysis will be executed using R.'
+  mainLanguage:
+    type: string
+    description: The main language in which this course is given. A string formatted according to RFC3066.
+    example: nl-NL
   learningOutcomes:
     type: array
     description: Statements that describe the knowledge or skills students should acquire by the end of a particular course (ECTS-learningoutcome). [Our internal Markdown syntax](#tag/formatting-and-displaying-results-from-API) MAY be used for rich text representation.

--- a/v5/schemas/Offering.yaml
+++ b/v5/schemas/Offering.yaml
@@ -5,7 +5,6 @@ required:
   - type
   - name
   - description
-  - mainLanguage
   - isLineItem
 properties:
   offeringId:
@@ -52,10 +51,6 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
-  mainLanguage:
-    type: string
-    description: The main language in which the courses within this program are given, RFC3066
-    example: nl-NL
   maxNumberStudents:
     type: number
     description: The maximum number of students allowed to enroll for this offering

--- a/v5/schemas/Offering.yaml
+++ b/v5/schemas/Offering.yaml
@@ -51,6 +51,10 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
+  teachingLanguage:
+    type: string
+    description: The teaching language in which this offering is given. A string formatted according to RFC3066. In principle this should be the same language as the Program, Course or Component for which this is an offering.
+    example: nl-NL
   maxNumberStudents:
     type: number
     description: The maximum number of students allowed to enroll for this offering

--- a/v5/schemas/Program.yaml
+++ b/v5/schemas/Program.yaml
@@ -6,6 +6,7 @@ required:
   - name
   - abbreviation
   - description
+  - mainLanguage
 properties:
   programId:
     type: string
@@ -28,6 +29,10 @@ properties:
     type: string
     description: The description of this program. [Our internal Markdown syntax](#tag/formatting-and-displaying-results-from-API) MAY be used for rich text representation.
     example: program that is a place holder for all courses that are made available for student mobility
+  mainLanguage:
+    type: string
+    description: The main language in which this program is given. A string formatted according to RFC3066.
+    example: nl-NL
   ects:
     type: number
     description: The number of Euopean Credits that can be archieved in this program


### PR DESCRIPTION
This PR fixes #162 and also improves compatibility with RIO by moving the `mainLanguage` attribute from offerings to Programs, Courses and Offerings.