### PR TITLE
Bring back some missing 404s

### DIFF
--- a/v5/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5/paths/AcademicSessionOfferingCollection.yaml
@@ -118,6 +118,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/BuildingRoomCollection.yaml
+++ b/v5/paths/BuildingRoomCollection.yaml
@@ -75,6 +75,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/ComponentOfferingCollection.yaml
+++ b/v5/paths/ComponentOfferingCollection.yaml
@@ -105,6 +105,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/CourseComponentCollection.yaml
+++ b/v5/paths/CourseComponentCollection.yaml
@@ -78,6 +78,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -111,6 +111,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/NewsFeedItemCollection.yaml
+++ b/v5/paths/NewsFeedItemCollection.yaml
@@ -84,6 +84,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/OfferingAssociationCollection.yaml
+++ b/v5/paths/OfferingAssociationCollection.yaml
@@ -110,6 +110,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/OrganizationComponentCollection.yaml
+++ b/v5/paths/OrganizationComponentCollection.yaml
@@ -78,6 +78,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/OrganizationCourseCollection.yaml
+++ b/v5/paths/OrganizationCourseCollection.yaml
@@ -86,6 +86,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/OrganizationOfferingCollection.yaml
+++ b/v5/paths/OrganizationOfferingCollection.yaml
@@ -118,6 +118,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/OrganizationProgramCollection.yaml
+++ b/v5/paths/OrganizationProgramCollection.yaml
@@ -110,6 +110,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/PersonAssociationCollection.yaml
+++ b/v5/paths/PersonAssociationCollection.yaml
@@ -127,6 +127,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/ProgramCourseCollection.yaml
+++ b/v5/paths/ProgramCourseCollection.yaml
@@ -86,6 +86,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':

--- a/v5/paths/ProgramOfferingCollection.yaml
+++ b/v5/paths/ProgramOfferingCollection.yaml
@@ -111,6 +111,8 @@ get:
       $ref: '../schemas/ErrorUnauthorized.yaml'
     '403':
       $ref: '../schemas/ErrorForbidden.yaml'
+    '404':
+      $ref: '../schemas/ErrorNotFound.yaml'
     '405':
       $ref: '../schemas/ErrorMethodNotAllowed.yaml'
     '429':


### PR DESCRIPTION
This PR brings back some missing 404 error codes. When requesting a path like `/program/{programId}/offerings` that returns a collection, the response can still be a 404, because it is possible `{programId}` could not be found.