### PR TITLE
Add `addresses` to all offerings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ext objects to all collection endpoints
 - #158 Improve error responses to make them more semantically correct
 - Added descriptions for HTTP error responses: 400, 401, 403, 404, 405, 429 and 500. Fixes #125 and #144.
-- #164 Add `addresses` to all offerings
+- #164 Add `addresses` to Program, Course, Offering and Component schema's
 
 ### Changed
 - rename of changed.md file on version level to release file on version level to provide for additional release information fo future releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ext objects to all collection endpoints
 - #158 Improve error responses to make them more semantically correct
 - Added descriptions for HTTP error responses: 400, 401, 403, 404, 405, 429 and 500. Fixes #125 and #144.
+- #164 Add `addresses` to all offerings
 
 ### Changed
 - rename of changed.md file on version level to release file on version level to provide for additional release information fo future releases

--- a/v5/schemas/Component.yaml
+++ b/v5/schemas/Component.yaml
@@ -43,5 +43,10 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
+  addresses:
+    type: array
+    description: Addresses for this component
+    items:
+      $ref: './Address.yaml'
   ext:
     $ref: './Ext.yaml'

--- a/v5/schemas/ComponentOffering.yaml
+++ b/v5/schemas/ComponentOffering.yaml
@@ -21,5 +21,10 @@ allOf:
         minimum: 0
         maximum: 100
         example: 100
+      addresses:
+        type: array
+        description: Addresses for this offering
+        items:
+          $ref: './Address.yaml'
       room:
         $ref: './Room.yaml'

--- a/v5/schemas/Course.yaml
+++ b/v5/schemas/Course.yaml
@@ -79,5 +79,10 @@ properties:
     format: uri
     maxLength: 2048
     example: https://osiris.uu.nl/osiris_student_uuprd/OnderwijsCatalogusZoekCursus.do#submitForm?cursuscode=INFOMQNM
+  addresses:
+    type: array
+    description: Addresses for this course
+    items:
+      $ref: './Address.yaml'
   ext:
     $ref: './Ext.yaml'

--- a/v5/schemas/CourseOffering.yaml
+++ b/v5/schemas/CourseOffering.yaml
@@ -16,3 +16,8 @@ allOf:
         type: string
         description: The moment on which this offering ends, RFC3339 (full-date)
         format: date
+      addresses:
+        type: array
+        description: Addresses for this offering
+        items:
+          $ref: './Address.yaml'

--- a/v5/schemas/Offering.yaml
+++ b/v5/schemas/Offering.yaml
@@ -80,5 +80,10 @@ properties:
     example: true
   resultValueType:
     $ref: '../enumerations/resultValueType.yaml'
+  addresses:
+    type: array
+    description: Addresses for this offering
+    items:
+      $ref: './Address.yaml'
   ext:
     $ref: './Ext.yaml'

--- a/v5/schemas/Program.yaml
+++ b/v5/schemas/Program.yaml
@@ -71,5 +71,10 @@ properties:
     format: uri
     maxLength: 2048
     example: https://bijvak.nl
+  addresses:
+    type: array
+    description: Addresses for this program
+    items:
+      $ref: './Address.yaml'
   ext:
     $ref: './Ext.yaml'

--- a/v5/schemas/ProgramOffering.yaml
+++ b/v5/schemas/ProgramOffering.yaml
@@ -18,3 +18,8 @@ allOf:
         description: The moment on which this offering ends, RFC3339 (full-date)
         format: date
         example: 2023-06-15
+      addresses:
+        type: array
+        description: Addresses for this offering
+        items:
+          $ref: './Address.yaml'


### PR DESCRIPTION
Uitwerking van optie 2 in #164

Adresinformatie toegevoegd aan alle schema's met onderwijsaanbod:
- Offering
- Program
- ProgramOffering
- Component
- ComponentOffering
- Course
- CourseOffering


Gemaakte keuzes:
- Op alle plekken de array `addresses` toegevoegd omdat het aanbod verdeeld kan zijn over meerdere fysieke locaties
- Ieder array-item is een referentie naar het bestaande schema `Address.yaml`
- Niet verplicht
