### PR TITLE
Adds extensible enumeration for costType

### DIFF
--- a/v5-beta/enumerations/costType.yaml
+++ b/v5-beta/enumerations/costType.yaml
@@ -1,0 +1,13 @@
+type: string
+description: |
+  The type of the cost. This is an *extensible enumeration*.
+
+  The following values have been defined in the specification:
+    - `STAP eligible`: the costs that a student can get STAP subsidy for
+    - `total costs`: the total costs that a student is to pay to follow this offering
+  
+  Implementations are allowed to add additional values to those above, as long as they do not overlap in definition to existing values.
+example: total costs
+x-ooapi-extensible-enum:
+  - STAP eligible
+  - total costs

--- a/v5-beta/schemas/Cost.yaml
+++ b/v5-beta/schemas/Cost.yaml
@@ -5,11 +5,7 @@ required:
   - currency
 properties:
   costType:
-    type: string
-    description: The type of cost
-    enum:
-      - STAP eligible
-      - total costs
+    $ref: '../enumerations/costType.yaml'
   amount:
     type: string
     pattern: '^\d+(?:\.\d+)?$'


### PR DESCRIPTION
Deze PR maakt van `costType` een extensible enumeratie. De enumeratie is nu als volgt gespecificeerd:

```yaml
type: string
description: |
  The type of the cost. This is an *extensible enumeration*.

  The following values have been defined in the specification:
    - `STAP eligible`: the costs that a student can get STAP subsidy for
    - `total costs`: the total costs that a student is to pay to follow this offering
  
  Implementations are allowed to add additional values to those above, as long as they do not overlap in definition to existing values.
example: total costs
x-ooapi-extensible-enum:
  - STAP eligible
  - total costs
```

En rendert als volgt:

![costtype-enum](https://user-images.githubusercontent.com/2357145/167125362-a6a08065-2141-4025-8588-8cc7da8f138d.png)

Een belangrijke consequentie door de enumeratie op deze manier te specificeren is dat automatische validatie tools alle string waarden voor `costType` goedkeuren. Door de property `x-ooapi-extensible-enum` toe te voegen, houden we de mogelijkheid open om later custom tooling te ontwikkelen die bijv. kan waarschuwen als er een waarde wordt gebruikt die wel is toegestaan, maar die niet voorkomt in de lijst met voorgedefinieerde waarden.

Het feit dat de enumeratie extensible is wordt dus vooral duidelijk door het in de description toe te lichten.