### PR TITLE
Improve identifier types

### DIFF
--- a/v5-beta/enumerations/codeType.yaml
+++ b/v5-beta/enumerations/codeType.yaml
@@ -1,0 +1,51 @@
+type: string
+description: |
+  The code/identifier type
+  - brin: The registration number for a Dutch educational institution that is issued by the Dutch Ministry of Education, Culture and Science
+  - crohoCreboCode: programs with a CREBO and CROHO number are accredited by the Dutch Ministry of Education, Culture and Science (OCW)
+  - programCode: Identifier for the program (collection of courses)
+  - componentCode: The code for a component (part of a course)
+  - offeringCode: The code to identify a specific offering (program, course or component offering)
+  - orgId: The identifier for the organization
+  - buildingId: The number or code to identify a building
+  - bagId: The identification of a building as it is known in the Dutch Building Administration (BAG)
+  - roomCode: The code for a room
+  - systemId: Identifier assigned to an entity in context of a specific system
+  - productId: Identifier assigned to a specific product
+  - nationalIdentityNumber: Identifier assigned by the governement of the person. e.g. a social security number in the USA
+  - studentNumber: Identifier for the person
+  - esi: European Student Identifier
+  - userName: The name of a user
+  - accountId: Identifier assigned to a specific account
+  - emailAdress: An email address
+  - groupCode: The identifier for a group (of persons)
+  - isbn: International Standard Book Number that serve as product identifiers for Books
+  - issn:	International Standard Book Number that serve as product identifiers for periodicals
+  - orcId: Open Researcher and Contributor ID
+  - uuid: A universally unique identifier
+  - identifier: Generic Identifier
+x-ooapi-extensible-enum:
+  - brin
+  - crohoCreboCode
+  - programCode
+  - componentCode
+  - offeringCode
+  - orgId
+  - buildingId
+  - bagId
+  - roomCode
+  - systemId
+  - productId
+  - nationalIdentityNumber
+  - studentNumber
+  - esi
+  - userName
+  - accountId
+  - emailAdress
+  - groupCode
+  - isbn
+  - issn
+  - orcId
+  - uuid
+  - identifier
+example: crohoCreboCode

--- a/v5-beta/enumerations/codeType.yaml
+++ b/v5-beta/enumerations/codeType.yaml
@@ -1,29 +1,33 @@
 type: string
 description: |
-  The code/identifier type
-  - brin: The registration number for a Dutch educational institution that is issued by the Dutch Ministry of Education, Culture and Science
-  - crohoCreboCode: programs with a CREBO and CROHO number are accredited by the Dutch Ministry of Education, Culture and Science (OCW)
-  - programCode: Identifier for the program (collection of courses)
-  - componentCode: The code for a component (part of a course)
-  - offeringCode: The code to identify a specific offering (program, course or component offering)
-  - orgId: The identifier for the organization
-  - buildingId: The number or code to identify a building
-  - bagId: The identification of a building as it is known in the Dutch Building Administration (BAG)
-  - roomCode: The code for a room
-  - systemId: Identifier assigned to an entity in context of a specific system
-  - productId: Identifier assigned to a specific product
-  - nationalIdentityNumber: Identifier assigned by the governement of the person. e.g. a social security number in the USA
-  - studentNumber: Identifier for the person
-  - esi: European Student Identifier
-  - userName: The name of a user
-  - accountId: Identifier assigned to a specific account
-  - emailAdress: An email address
-  - groupCode: The identifier for a group (of persons)
-  - isbn: International Standard Book Number that serve as product identifiers for Books
-  - issn: International Standard Book Number that serve as product identifiers for periodicals
-  - orcId: Open Researcher and Contributor ID
-  - uuid: A universally unique identifier
-  - identifier: Generic Identifier
+  The code/identifier type. 
+  
+  This is an *extensible enumeration*. Use `x-` to prefix custom values
+  
+  The predefined values are:
+    - `brin`: The registration number for a Dutch educational institution that is issued by the Dutch Ministry of Education, Culture and Science
+    - `crohoCreboCode`: programs with a CREBO and CROHO number are accredited by the Dutch Ministry of Education, Culture and Science (OCW)
+    - `programCode`: Identifier for the program (collection of courses)
+    - `componentCode`: The code for a component (part of a course)
+    - `offeringCode`: The code to identify a specific offering (program, course or component offering)
+    - `orgId`: The identifier for the organization
+    - `buildingId`: The number or code to identify a building
+    - `bagId`: The identification of a building as it is known in the Dutch Building Administration (BAG)
+    - `roomCode`: The code for a room
+    - `systemId`: Identifier assigned to an entity in context of a specific system
+    - `productId`: Identifier assigned to a specific product
+    - `nationalIdentityNumber`: Identifier assigned by the governement of the person. e.g. a social security number in the USA
+    - `studentNumber`: Identifier for the person
+    - `esi`: European Student Identifier
+    - `userName`: The name of a user
+    - `accountId`: Identifier assigned to a specific account
+    - `emailAdress`: An email address
+    - `groupCode`: The identifier for a group (of persons)
+    - `isbn`: International Standard Book Number that serve as product identifiers for Books
+    - `issn`: International Standard Book Number that serve as product identifiers for periodicals
+    - `orcId`: Open Researcher and Contributor ID
+    - `uuid`: A universally unique identifier
+    - `identifier`: Generic Identifier
 x-ooapi-extensible-enum:
   - brin
   - crohoCreboCode

--- a/v5-beta/schemas/Building.yaml
+++ b/v5-beta/schemas/Building.yaml
@@ -15,8 +15,8 @@ properties:
     description: The primary human readable identifier for this building. This is often the source identifier as defined by the institution.
     $ref: './IdentifierEntry.yaml'
     example:
-      codeType: BAG
-      code: '0344100000139910'
+      codeType: buildingId
+      code: '45'
   abbreviation:
     type: string
     description: The abbreviation of the name of this building
@@ -48,7 +48,7 @@ properties:
     items:
       $ref: './IdentifierEntry.yaml'
     example:
-      - codeType: BAG
+      - codeType: bagId
         code: '0344100000139910'
   consumers:
     description: The additional consumer elements that can be provided

--- a/v5-beta/schemas/EducationSpecificationProperties.yaml
+++ b/v5-beta/schemas/EducationSpecificationProperties.yaml
@@ -4,6 +4,7 @@ description: |
   It is used to aggregate education objects from a supplying institution.
   It clusters programs to a main educationSpecification that is used in registries such as RIO.
 required:
+  - primaryCode
   - educationSpecificationType
   - name
   - startDate
@@ -19,7 +20,7 @@ properties:
     items:
       $ref: './IdentifierEntry.yaml'
     example:
-      - codeType: Crebo
+      - codeType: crohoCreboCode
         code: '1234123'
   educationSpecificationType:
     $ref: '../enumerations/educationSpecificationType.yaml'

--- a/v5-beta/schemas/IdentifierEntry.yaml
+++ b/v5-beta/schemas/IdentifierEntry.yaml
@@ -1,8 +1,7 @@
 type: object
 properties:
   codeType:
-    description: The type of the code/identifier
-    type: string
+    $ref: '../enumerations/codeType.yaml'
   code:
     description: Human readable value for the code/identifier
     type: string

--- a/v5-beta/schemas/PersonProperties.yaml
+++ b/v5-beta/schemas/PersonProperties.yaml
@@ -14,6 +14,8 @@ properties:
     example:
       codeType: studentNumber
       code: 0000000
+    # Returned by GET, not used in POST/PUT/PATCH
+    readOnly: true
   givenName:
     type: string
     description: The first name of this person

--- a/v5-beta/schemas/PersonProperties.yaml
+++ b/v5-beta/schemas/PersonProperties.yaml
@@ -134,7 +134,7 @@ properties:
     items:
       $ref: './IdentifierEntry.yaml'
     example:
-      - codeType: BSN
+      - codeType: nationalIdentityNumber
         code: '00000'
   consumers:
     description: The additional consumer elements that can be provided


### PR DESCRIPTION
1. Vrij invulbare string voor `codeType` aangepast naar een extensible enum. Dit heeft impact op alle primaryCode en otherCode attributen
2. Aantal kleine aanpassingen in de `primaryCode` en `otherCodes` voorbeelden om het geheel consistenter te maken
3. In PersonProporties schema het attribuut `primaryCode` als readOnly gemarkeerd zodat deze niet verplicht is in POST /persons