### PR TITLE
Adds the activeEnrollment attribute to person

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds the attribute `fieldsOfStudy` to Course
 - Adds the attribute `level` to Program.
 - Make the enumeration of AcademicSession `type` extensible and add the following options: `trimester`, `quarter` and `testing period`.
+- Adds the attribute `activeEnrollment` to Person.
 
 ### Changed
 - rename of changed.md file on version level to release file on version level to provide for additional release information fo future releases

--- a/v5-beta/schemas/PersonProperties.yaml
+++ b/v5-beta/schemas/PersonProperties.yaml
@@ -7,6 +7,7 @@ required:
   - affiliations
   - mail
   - primaryCode
+  - activeEnrollment
 properties:
   primaryCode:
     description: The primary human readable identifier for the person. This is often the source identifier as defined by the institution.
@@ -39,6 +40,10 @@ properties:
     type: string
     description: The initials of this person
     example: MCW
+  activeEnrollment:
+    type: boolean
+    description: Whether this person has an active enrollment.
+    example: false
   dateOfBirth:
     type: string
     description: The date of birth of this person, RFC3339 (full-date)


### PR DESCRIPTION
Deze PR voegt het activeEnrollment attribuut toe aan Person. Het attribuut is bedoeld voor de pilot studentmobiliteit. Het idee is dat instellingen onderling bepalen wat activeEnrollment precies betekent, voor de pilot studentmobiliteit zal dat bewijs betaald collegegeld zijn.
