### PR TITLE
Add children attribute to EducationSpecification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0 RC2] - 2022-06-10
+- Adds an expandable `children` attribute to EducationSpecification.
+
 ## [5.0.0 RC1] - 2022-06-08
 
 ### Added

--- a/v5-rc/paths/EducationSpecificationInstance.yaml
+++ b/v5-rc/paths/EducationSpecificationInstance.yaml
@@ -22,6 +22,7 @@ get:
           type: string
           enum:
             - parent
+            - children
             - organization
   responses:
     '200':

--- a/v5-rc/schemas/EducationSpecificationProperties.yaml
+++ b/v5-rc/schemas/EducationSpecificationProperties.yaml
@@ -84,6 +84,15 @@ properties:
         title: educationSpecificationId
       - $ref: './EducationSpecification.yaml'
         title: EducationSpecification
+  children:
+    type: array
+    description: The EducationSpecifications that have this EducationSpecification as their parent. [`expandable`](#tag/education_specification_model)
+    items:
+      oneOf:
+        - $ref: './Identifier.yaml'
+          title: educationSpecificationId
+        - $ref: './EducationSpecification.yaml'
+          title: EducationSpecification
   organization:
     description: |
       The organization that manages this group. [`expandable`](#tag/organization_model)

--- a/v5-rc/spec.yaml
+++ b/v5-rc/spec.yaml
@@ -1,6 +1,6 @@
 openapi: "3.1.0"
 info:
-  version: "5.0.0 RC1"
+  version: "5.0.0 RC2"
   title: Open Education API
   description: |
     OpenAPI (fka Swagger) specification for the Open Education API.


### PR DESCRIPTION
This PR adds an expandable `children` attribute to EducationSpecification.
