### PR TITLE
Example: use component refs instead of recursive includes.

### DIFF
--- a/v5-rc/paths/EducationSpecificationCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationCollection.yaml
@@ -53,7 +53,7 @@ get:
                   items:
                     type: array
                     items:
-                      $ref: '../schemas/EducationSpecification.yaml'
+                      $ref: '#/components/schemas/EducationSpecification'
                   ext:
                     $ref: '../schemas/Ext.yaml'
     '400':

--- a/v5-rc/paths/EducationSpecificationEducationSpecificationCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationEducationSpecificationCollection.yaml
@@ -48,7 +48,7 @@ get:
                   items:
                     type: array
                     items:
-                      $ref: '../schemas/Course.yaml'
+                      $ref: '../schemas/Course.yaml'  # TODO: This should probably be an EducationSpecification!
                   ext:
                     $ref: '../schemas/Ext.yaml'
     '400':

--- a/v5-rc/paths/EducationSpecificationInstance.yaml
+++ b/v5-rc/paths/EducationSpecificationInstance.yaml
@@ -31,9 +31,9 @@ get:
           schema:
             oneOf:
               - title: Without timelineOverrides (default)
-                $ref: '../schemas/EducationSpecification.yaml'
+                $ref: '#/components/schemas/EducationSpecification'
               - title: With timelineOverrides
-                $ref: '../schemas/EducationSpecificationExpanded.yaml'
+                $ref: '#/components/schemas/EducationSpecificationExpanded'
     '400':
       $ref: '../schemas/ErrorBadRequest.yaml'
     '401':

--- a/v5-rc/paths/OrganizationEducationSpecificationCollection.yaml
+++ b/v5-rc/paths/OrganizationEducationSpecificationCollection.yaml
@@ -53,7 +53,7 @@ get:
                   items:
                     type: array
                     items:
-                      $ref: '../schemas/EducationSpecification.yaml'
+                      $ref: '#/components/schemas/EducationSpecification'
                   ext:
                     $ref: '../schemas/Ext.yaml'
     '400':

--- a/v5-rc/schemas/CourseProperties.yaml
+++ b/v5-rc/schemas/CourseProperties.yaml
@@ -118,9 +118,13 @@ properties:
   educationSpecification:
     description: The educationSpecification of which this course is a more concrete implementation. [`expandable`](#tag/education_specification_model)
     oneOf:
-      - $ref: './Identifier.yaml'
-        title: educationSpecificationId
-      - $ref: './EducationSpecification.yaml'
+      - $ref: '#/components/schemas/EducationSpecificationId'
+        title: educationSpecificationId # NOTE: According to the
+                                        # openapi spec, $refs
+                                        # completely replace their
+                                        # sibling attributes, so
+                                        # `title` here will be lost
+      - $ref: '#/components/schemas/EducationSpecification'
         title: EducationSpecification
   addresses:
     type: array

--- a/v5-rc/schemas/EducationSpecification.yaml
+++ b/v5-rc/schemas/EducationSpecification.yaml
@@ -1,6 +1,6 @@
 allOf:
-  - $ref: '../schemas/EducationSpecificationId.yaml'
-  - $ref: '../schemas/EducationSpecificationProperties.yaml'
+  - $ref: '#/components/schemas/EducationSpecificationId'
+  - $ref: '#/components/schemas/EducationSpecificationProperties'
   - properties:
       validFrom:
         description: The first day this EducationSpecification is valid (inclusive).

--- a/v5-rc/schemas/EducationSpecificationExpanded.yaml
+++ b/v5-rc/schemas/EducationSpecificationExpanded.yaml
@@ -1,5 +1,5 @@
 allOf:
-  - $ref: '../schemas/EducationSpecification.yaml'
+  - $ref: '#/components/schemas/EducationSpecification'
   - type: object
     title: With timelineOverrides
     properties:

--- a/v5-rc/schemas/EducationSpecificationProperties.yaml
+++ b/v5-rc/schemas/EducationSpecificationProperties.yaml
@@ -80,9 +80,9 @@ properties:
   parent:
     description: The educationSpecification that is the parent of this educationSpecification if it exists. [`expandable`](#tag/education_specification_model)
     oneOf:
-      - $ref: './Identifier.yaml'
+      - $ref: '#/components/schemas/EducationSpecificationId'
         title: educationSpecificationId
-      - $ref: './EducationSpecification.yaml'
+      - $ref: '#/components/schemas/EducationSpecification'
         title: EducationSpecification
   organization:
     description: |

--- a/v5-rc/schemas/ProgramProperties.yaml
+++ b/v5-rc/schemas/ProgramProperties.yaml
@@ -131,9 +131,9 @@ properties:
   educationSpecification:
     description: The educationSpecification of which this program is a more concrete implementation. [`expandable`](#tag/education_specification_model)
     oneOf:
-      - $ref: './Identifier.yaml'
+      - $ref: '#/components/schemas/EducationSpecificationId'
         title: educationSpecificationId
-      - $ref: './EducationSpecification.yaml'
+      - $ref: '#/components/schemas/EducationSpecification'
         title: EducationSpecification
   otherCodes:
     type: array

--- a/v5-rc/schemas/TimelineOverrideEducationSpecification.yaml
+++ b/v5-rc/schemas/TimelineOverrideEducationSpecification.yaml
@@ -15,4 +15,4 @@ properties:
     format: date
     example: 2022-08-31
   educationSpecification:
-    $ref: './EducationSpecificationProperties.yaml'
+    $ref: '#/components/schemas/EducationSpecificationProperties'

--- a/v5-rc/spec.yaml
+++ b/v5-rc/spec.yaml
@@ -257,9 +257,14 @@ components:
     CourseOffering:
       allOf:
         - $ref: schemas/CourseOffering.yaml
+    EducationSpecificationId:
+      $ref: schemas/EducationSpecificationId.yaml
+    EducationSpecificationProperties:
+      $ref: schemas/EducationSpecificationProperties.yaml
     EducationSpecification:
-      allOf:
-        - $ref: schemas/EducationSpecification.yaml
+      $ref: schemas/EducationSpecification.yaml
+    EducationSpecificationExpanded:
+      $ref: schemas/EducationSpecificationExpanded.yaml
     Group:
       allOf:
         - $ref: schemas/Group.yaml


### PR DESCRIPTION
This is an example of the use of internal $refs for schema reuse. The
existing implementation used external includes that included schemas
recursively, and the tooling for the Eduhub gateway breaks on those
constructs.

This new setup should result in an overall smaller specification since
reuse is explicit via components.

This commit implements the changes only for EducationSpecification as
an example and to validate the technique. The idea is to implement
this for all schema objects that are used in the spec.

The same strategy can be used for responses, parameters, and
enumerations (which are a specific subset of schemas). See
https://swagger.io/docs/specification/components/ for the full list of
available component types.