### PR TITLE
Add ParticuliereOpleiding categorie field to RIO Consumer

### DIFF
--- a/docs/consumers/rio.md
+++ b/docs/consumers/rio.md
@@ -536,7 +536,7 @@ See also [this overview of language tags](https://www.loc.gov/standards/iso639-2
 | business_and_project_support             | BEDRIJFS_EN_PROJECTONDERSTEUNING         |
 | economy                                  | ECONOMIE                                 |
 | behavior_and_society                     | GEDRAG_EN_MAATSCHAPPIJ                   |
-| health_care_and_sport                    | GEZONDHEID_ZORG_EN_SPORT                 |
+| healthcare_and_sport                     | GEZONDHEID_ZORG_EN_SPORT                 |
 | hobby_and_leisure_time                   | HOBBY_EN_VRIJE_TIJD                      |
 | agriculture_food_and_natural_environment | LANDBOUW_VOEDSEL_EN_NATUURLIJKE_OMGEVING |
 | management_and_project_management        | MANAGEMENT_EN_PROJECTMANAGEMENT          |

--- a/v5-rc/consumers/RIO/V1/EducationSpecification.yaml
+++ b/v5-rc/consumers/RIO/V1/EducationSpecification.yaml
@@ -20,7 +20,7 @@ properties:
       - business_and_project_support
       - economy
       - behavior_and_society
-      - health_care_and_sport
+      - healthcare_and_sport
       - hobby_and_leisure_time
       - agriculture_food_and_natural_environment
       - management_and_project_management


### PR DESCRIPTION
Adds the new RIO categorie field of ParticuliereOpleiding field to the RIO Consumer object and updates the specification.