### PR TITLE
Fixed example for admissionRequirements

### DIFF
--- a/v5-rc/schemas/CourseProperties.yaml
+++ b/v5-rc/schemas/CourseProperties.yaml
@@ -74,7 +74,9 @@ properties:
   admissionRequirements:
     type: array
     description: This information may be given at an institutional level and/or at the level of individual programmes. Make sure that it is clear whether the information applies to fee-paying students (national and/or international) or to exchange students.
-    example: Students need to be enrolled at qualifying institutions of higher education that participate in this alliance
+    example: 
+      - language: en-GB
+        value: Students need to be enrolled at qualifying institutions of higher education that participate in this alliance
     minItems: 1
     items:
       $ref: './LanguageTypedString.yaml'

--- a/v5-rc/schemas/ProgramProperties.yaml
+++ b/v5-rc/schemas/ProgramProperties.yaml
@@ -112,7 +112,9 @@ properties:
   admissionRequirements:
     type: array
     description: This information may be given at an institutional level and/or at the level of individual programmes. Make sure that it is clear whether the information applies to fee-paying students (national and/or international) or to exchange students.
-    example: Students need to be enrolled at qualifying institutions of higher education that participate in this alliance
+    example: 
+      - language: en-GB
+        value: Students need to be enrolled at qualifying institutions of higher education that participate in this alliance
     minItems: 1
     items:
       $ref: './LanguageTypedString.yaml'


### PR DESCRIPTION
The property admissionRequirements is an array of LanguageTypedString, and that should be reflected in the example, which was a string.