### PR TITLE
Fixed codeType example value in ProgramProperties.

### DIFF
--- a/v5-rc/schemas/ProgramProperties.yaml
+++ b/v5-rc/schemas/ProgramProperties.yaml
@@ -141,7 +141,7 @@ properties:
     items:
       $ref: './IdentifierEntry.yaml'
     example:
-    - codeType: CROHO
+    - codeType: crohoCreboCode
       code: '59312'
   addresses:
     type: array


### PR DESCRIPTION
According to v5-rc/enumerations/codeType.yaml, the value CROHO is not allowed; probably the enum value crohoCreboCode was intended.
