### PR TITLE
Downgrade to Openapi v3.0.3 for better tooling support

### DIFF
--- a/v5-rc/paths/AcademicSessionCollection.yaml
+++ b/v5-rc/paths/AcademicSessionCollection.yaml
@@ -43,7 +43,7 @@ get:
           - -academicSessionId
           - -name
           - -startDate
-        default: startDate
+        default: [ startDate ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/AcademicSessionCollection.yaml
+++ b/v5-rc/paths/AcademicSessionCollection.yaml
@@ -44,6 +44,9 @@ get:
           - -name
           - -startDate
         default: [ startDate ]
+        example: 
+          - startDate
+          - -academicSessionId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5-rc/paths/AcademicSessionOfferingCollection.yaml
@@ -65,6 +65,9 @@ get:
             - -startDate
             - -endDate
         default: [ startDate ]
+        example:
+          - startDate
+          - -name
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/AcademicSessionOfferingCollection.yaml
+++ b/v5-rc/paths/AcademicSessionOfferingCollection.yaml
@@ -64,7 +64,7 @@ get:
             - -name
             - -startDate
             - -endDate
-        default: startDate
+        default: [ startDate ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/BuildingCollection.yaml
+++ b/v5-rc/paths/BuildingCollection.yaml
@@ -24,6 +24,9 @@ get:
           - -buildingId
           - -name
         default: [ name ]
+        example:
+          - name
+          - -buildingId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/BuildingCollection.yaml
+++ b/v5-rc/paths/BuildingCollection.yaml
@@ -23,7 +23,7 @@ get:
           - name
           - -buildingId
           - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/BuildingRoomCollection.yaml
+++ b/v5-rc/paths/BuildingRoomCollection.yaml
@@ -39,7 +39,7 @@ get:
             - -name
             - -totalSeats
             - -availableSeats
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/BuildingRoomCollection.yaml
+++ b/v5-rc/paths/BuildingRoomCollection.yaml
@@ -40,6 +40,9 @@ get:
             - -totalSeats
             - -availableSeats
         default: [ name ]
+        example:
+          - name
+          - -availableSeats
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ComponentOfferingCollection.yaml
+++ b/v5-rc/paths/ComponentOfferingCollection.yaml
@@ -54,7 +54,7 @@ get:
             - -name
             - -startDateTime
             - -endDateTime
-        default: startDateTime
+        default: [ startDateTime ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ComponentOfferingCollection.yaml
+++ b/v5-rc/paths/ComponentOfferingCollection.yaml
@@ -55,6 +55,9 @@ get:
             - -startDateTime
             - -endDateTime
         default: [ startDateTime ]
+        example:
+          - offeringId
+          - -startDateTime
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/CourseCollection.yaml
+++ b/v5-rc/paths/CourseCollection.yaml
@@ -37,6 +37,9 @@ get:
             - -courseId
             - -name
         default: [ name ]
+        example:
+          - name
+          - -courseId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/CourseCollection.yaml
+++ b/v5-rc/paths/CourseCollection.yaml
@@ -36,7 +36,7 @@ get:
             - name
             - -courseId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/CourseComponentCollection.yaml
+++ b/v5-rc/paths/CourseComponentCollection.yaml
@@ -37,6 +37,9 @@ get:
             - -componentId
             - -name
         default: [ componentId ]
+        example:
+          - name
+          - -componentId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/CourseComponentCollection.yaml
+++ b/v5-rc/paths/CourseComponentCollection.yaml
@@ -36,7 +36,7 @@ get:
             - name
             - -componentId
             - -name
-        default: componentId
+        default: [ componentId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/CourseOfferingCollection.yaml
+++ b/v5-rc/paths/CourseOfferingCollection.yaml
@@ -61,6 +61,9 @@ get:
             - -startDate
             - -endDate
         default: [ startDate ]
+        example:
+           - offeringId
+           - -endDate
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/CourseOfferingCollection.yaml
+++ b/v5-rc/paths/CourseOfferingCollection.yaml
@@ -60,7 +60,7 @@ get:
             - -name
             - -startDate
             - -endDate
-        default: startDate
+        default: [ startDate ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationCollection.yaml
@@ -32,12 +32,15 @@ get:
           enum:
             - educationSpecificationType
             - name
-            - primarycode
+            - primaryCode
             - -educationSpecificationType
             - -name
-            - -primarycode
+            - -primaryCode
         default:
           - [ name ]
+        example:
+          - educationSpecificationType
+          - -primaryCode
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationCollection.yaml
@@ -37,7 +37,7 @@ get:
             - -name
             - -primarycode
         default:
-          - name
+          - [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationCourseCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationCourseCollection.yaml
@@ -42,6 +42,9 @@ get:
             - -courseId
             - -name
         default: [ courseId ]
+        example:
+          - courseId
+          - -name
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationCourseCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationCourseCollection.yaml
@@ -41,7 +41,7 @@ get:
             - name
             - -courseId
             - -name
-        default: courseId
+        default: [ courseId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationEducationSpecificationCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationEducationSpecificationCollection.yaml
@@ -32,7 +32,7 @@ get:
             - -educationSpecificationId
             - -name
             - -educationSpecificationType
-        default: educationSpecificationId
+        default: [ educationSpecificationId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationEducationSpecificationCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationEducationSpecificationCollection.yaml
@@ -33,6 +33,9 @@ get:
             - -name
             - -educationSpecificationType
         default: [ educationSpecificationId ]
+        example:
+          - educationSpecificationId
+          - -name
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationProgramCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationProgramCollection.yaml
@@ -67,6 +67,9 @@ get:
             - -programId
             - -name
         default: [ name ]
+        example:
+          - programId
+          - -name
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/EducationSpecificationProgramCollection.yaml
+++ b/v5-rc/paths/EducationSpecificationProgramCollection.yaml
@@ -66,7 +66,7 @@ get:
             - name
             - -programId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/GroupCollection.yaml
+++ b/v5-rc/paths/GroupCollection.yaml
@@ -31,7 +31,7 @@ get:
             - -groupId
             - -name
             - -startDate
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/GroupCollection.yaml
+++ b/v5-rc/paths/GroupCollection.yaml
@@ -32,6 +32,9 @@ get:
             - -name
             - -startDate
         default: [ name ]
+        example:
+          - groupId
+          - -startDate
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/GroupPersonCollection.yaml
+++ b/v5-rc/paths/GroupPersonCollection.yaml
@@ -39,7 +39,7 @@ get:
             - -givenName
             - -surName
             - -displayName
-        default: personId
+        default: [ personId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/GroupPersonCollection.yaml
+++ b/v5-rc/paths/GroupPersonCollection.yaml
@@ -40,6 +40,9 @@ get:
             - -surName
             - -displayName
         default: [ personId ]
+        example:
+          - personId
+          - -givenName
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/NewsFeedCollection.yaml
+++ b/v5-rc/paths/NewsFeedCollection.yaml
@@ -36,7 +36,7 @@ get:
             - name
             - -newsFeedId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/NewsFeedCollection.yaml
+++ b/v5-rc/paths/NewsFeedCollection.yaml
@@ -37,6 +37,9 @@ get:
             - -newsFeedId
             - -name
         default: [ name ]
+        example:
+          - name
+          - -newsFeedId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/NewsFeedItemCollection.yaml
+++ b/v5-rc/paths/NewsFeedItemCollection.yaml
@@ -41,7 +41,7 @@ get:
             - -validFrom
             - -validUntil
             - -lastModified
-        default: newsItemId
+        default: [ newsItemId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/NewsFeedItemCollection.yaml
+++ b/v5-rc/paths/NewsFeedItemCollection.yaml
@@ -42,6 +42,9 @@ get:
             - -validUntil
             - -lastModified
         default: [ newsItemId ]
+        example:
+          - validFrom
+          - -name
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OfferingAssociationCollection.yaml
+++ b/v5-rc/paths/OfferingAssociationCollection.yaml
@@ -44,7 +44,6 @@ get:
         $ref: '../enumerations/resultState.yaml'
     - name: sort
       in: query
-
       description: 'Sort by one or more attributes, the default is ascending. Prefixing the attribute with a minus sign `-` allows for descending sort. Examples: [ATTR | -ATTR | ATTR1,-ATTR2]'
       required: false
       schema:
@@ -56,6 +55,8 @@ get:
             - -associationId
         default:
         - associationId
+        example:
+          - associationId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OfferingGroupCollection.yaml
+++ b/v5-rc/paths/OfferingGroupCollection.yaml
@@ -38,6 +38,9 @@ get:
             - -name
             - -startDate
         default: [ name ]
+        example:
+          - name
+          - -startDate
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OfferingGroupCollection.yaml
+++ b/v5-rc/paths/OfferingGroupCollection.yaml
@@ -37,7 +37,7 @@ get:
             - -groupId
             - -name
             - -startDate
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationCollection.yaml
+++ b/v5-rc/paths/OrganizationCollection.yaml
@@ -29,7 +29,7 @@ get:
             - name
             - -organizationId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationCollection.yaml
+++ b/v5-rc/paths/OrganizationCollection.yaml
@@ -30,6 +30,9 @@ get:
             - -organizationId
             - -name
         default: [ name ]
+        example:
+          - name
+          - -organizationId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationComponentCollection.yaml
+++ b/v5-rc/paths/OrganizationComponentCollection.yaml
@@ -36,7 +36,7 @@ get:
             - name
             - -componentId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationComponentCollection.yaml
+++ b/v5-rc/paths/OrganizationComponentCollection.yaml
@@ -37,6 +37,9 @@ get:
             - -componentId
             - -name
         default: [ name ]
+        example:
+          - componentId
+          - -name
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationCourseCollection.yaml
+++ b/v5-rc/paths/OrganizationCourseCollection.yaml
@@ -42,7 +42,7 @@ get:
             - name
             - -courseId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationCourseCollection.yaml
+++ b/v5-rc/paths/OrganizationCourseCollection.yaml
@@ -43,6 +43,9 @@ get:
             - -courseId
             - -name
         default: [ name ]
+        example:
+          - name
+          - -courseId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationEducationSpecificationCollection.yaml
+++ b/v5-rc/paths/OrganizationEducationSpecificationCollection.yaml
@@ -37,7 +37,7 @@ get:
             - -educationSpecificationType
             - -name
             - -primarycode
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationEducationSpecificationCollection.yaml
+++ b/v5-rc/paths/OrganizationEducationSpecificationCollection.yaml
@@ -38,6 +38,9 @@ get:
             - -name
             - -primarycode
         default: [ name ]
+        example:
+          - name
+          - -educationSpecificationType
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationGroupCollection.yaml
+++ b/v5-rc/paths/OrganizationGroupCollection.yaml
@@ -38,6 +38,9 @@ get:
             - -name
             - -startDate
         default: [ name ]
+        example:
+          - groupId
+          - -name
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationGroupCollection.yaml
+++ b/v5-rc/paths/OrganizationGroupCollection.yaml
@@ -37,7 +37,7 @@ get:
             - -groupId
             - -name
             - -startDate
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationOfferingCollection.yaml
+++ b/v5-rc/paths/OrganizationOfferingCollection.yaml
@@ -65,6 +65,9 @@ get:
             - -startDate
             - -endDate
         default: [ startDate ]
+        example:
+          - name
+          - -startDate
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationOfferingCollection.yaml
+++ b/v5-rc/paths/OrganizationOfferingCollection.yaml
@@ -64,7 +64,7 @@ get:
             - -name
             - -startDate
             - -endDate
-        default: startDate
+        default: [ startDate ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationProgramCollection.yaml
+++ b/v5-rc/paths/OrganizationProgramCollection.yaml
@@ -61,6 +61,9 @@ get:
             - -programId
             - -name
         default: [ name ]
+        example:
+          - name
+          - -programId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/OrganizationProgramCollection.yaml
+++ b/v5-rc/paths/OrganizationProgramCollection.yaml
@@ -60,7 +60,7 @@ get:
             - name
             - -programId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/PersonAssociationCollection.yaml
+++ b/v5-rc/paths/PersonAssociationCollection.yaml
@@ -54,7 +54,7 @@ get:
           enum:
             - associationId
             - -associationId
-        default: associationId
+        default: [ associationId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/PersonAssociationCollection.yaml
+++ b/v5-rc/paths/PersonAssociationCollection.yaml
@@ -55,6 +55,8 @@ get:
             - associationId
             - -associationId
         default: [ associationId ]
+        example:
+          - associationId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/PersonCollection.yaml
+++ b/v5-rc/paths/PersonCollection.yaml
@@ -33,7 +33,7 @@ get:
             - -givenName
             - -surName
             - -displayName
-        default: personId
+        default: [ personId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/PersonCollection.yaml
+++ b/v5-rc/paths/PersonCollection.yaml
@@ -34,6 +34,9 @@ get:
             - -surName
             - -displayName
         default: [ personId ]
+        example:
+          - surName
+          - -personId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/PersonGroupCollection.yaml
+++ b/v5-rc/paths/PersonGroupCollection.yaml
@@ -38,6 +38,9 @@ get:
             - -name
             - -startDate
         default: [ name ]
+        example:
+          - name
+          - -groupId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/PersonGroupCollection.yaml
+++ b/v5-rc/paths/PersonGroupCollection.yaml
@@ -37,7 +37,7 @@ get:
             - -groupId
             - -name
             - -startDate
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramCollection.yaml
+++ b/v5-rc/paths/ProgramCollection.yaml
@@ -55,6 +55,9 @@ get:
             - -programId
             - -name
         default: [ name ]
+        sort:
+          - name
+          - programId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramCollection.yaml
+++ b/v5-rc/paths/ProgramCollection.yaml
@@ -54,7 +54,7 @@ get:
             - name
             - -programId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramCourseCollection.yaml
+++ b/v5-rc/paths/ProgramCourseCollection.yaml
@@ -43,6 +43,9 @@ get:
             - -courseId
             - -name
         default: [ courseId ]
+        example:
+          - name
+          - -courseId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramCourseCollection.yaml
+++ b/v5-rc/paths/ProgramCourseCollection.yaml
@@ -42,7 +42,7 @@ get:
             - name
             - -courseId
             - -name
-        default: courseId
+        default: [ courseId ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramOfferingCollection.yaml
+++ b/v5-rc/paths/ProgramOfferingCollection.yaml
@@ -61,7 +61,7 @@ get:
             - -startDate
             - -endDate
         default:
-          - startDate
+          - [ startDate ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramOfferingCollection.yaml
+++ b/v5-rc/paths/ProgramOfferingCollection.yaml
@@ -60,8 +60,10 @@ get:
             - -name
             - -startDate
             - -endDate
-        default:
-          - [ startDate ]
+        default: [ startDate ]
+        example:
+          - name
+          - -startDate
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramProgramCollection.yaml
+++ b/v5-rc/paths/ProgramProgramCollection.yaml
@@ -61,6 +61,9 @@ get:
             - -programId
             - -name
         default: [ name ]
+        example:
+          - name
+          - -programId
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/ProgramProgramCollection.yaml
+++ b/v5-rc/paths/ProgramProgramCollection.yaml
@@ -60,7 +60,7 @@ get:
             - name
             - -programId
             - -name
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/RoomCollection.yaml
+++ b/v5-rc/paths/RoomCollection.yaml
@@ -33,7 +33,7 @@ get:
             - -name
             - -totalSeats
             - -availableSeats
-        default: name
+        default: [ name ]
   responses:
     '200':
       description: OK

--- a/v5-rc/paths/RoomCollection.yaml
+++ b/v5-rc/paths/RoomCollection.yaml
@@ -34,6 +34,9 @@ get:
             - -totalSeats
             - -availableSeats
         default: [ name ]
+        example:
+          - name
+          - -availableSeats
   responses:
     '200':
       description: OK

--- a/v5-rc/schemas/Component.yaml
+++ b/v5-rc/schemas/Component.yaml
@@ -42,7 +42,7 @@ properties:
   duration:
     type: string
     description: The duration of this component. The duration format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.
-    format: duration
+    pattern: '^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$'
     example: P1DT30H4S
   description:
     type: array

--- a/v5-rc/schemas/CourseProperties.yaml
+++ b/v5-rc/schemas/CourseProperties.yaml
@@ -33,7 +33,7 @@ properties:
   duration:
     type: string
     description: The duration of this course. The duration format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.
-    format: duration
+    pattern: '^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$'
     example: P1DT30H4S
   firstStartDate:
     type: string

--- a/v5-rc/schemas/ProgramProperties.yaml
+++ b/v5-rc/schemas/ProgramProperties.yaml
@@ -58,7 +58,7 @@ properties:
   duration:
     type: string
     description: The duration of this program. The duration format is from the ISO 8601 ABNF as given in Appendix A of RFC 3339.
-    format: duration
+    pattern: '^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$'
     example: P1DT30H4S
   firstStartDate:
     type: string

--- a/v5-rc/spec.yaml
+++ b/v5-rc/spec.yaml
@@ -1,4 +1,4 @@
-openapi: "3.1.0"
+openapi: "3.0.3"
 info:
   version: "5.0.0 RC2"
   title: Open Education API


### PR DESCRIPTION
Current tooling & libraries generally do not yet support openapi
3.1.0. For instance, none of the data validation libraries at
https://openapi.tools/#data-validators supports it. 3.0.3 support is
widespread.

This change sets the version to 3.0.3 and fixes an issue with the
default values for the `sort` parameter, which should be an array, so
its default should also be an array.

Further consequences: the `duration` format is not explicitly
supported in 3.0.3, so strictly conforming validators will allow any
string value for `duration` fields. This patch replaces the `duration`
format with an explicit pattern matching the ISO8601 duration format.