### PR TITLE
Fixes missing primaryCode query parameter

### DIFF
--- a/v5/paths/AcademicSessionCollection.yaml
+++ b/v5/paths/AcademicSessionCollection.yaml
@@ -4,6 +4,7 @@ get:
   tags:
     - academic sessions
   parameters:
+    - $ref: '../parameters/primaryCode.yaml'
     - $ref: '../parameters/pageSize.yaml'
     - $ref: '../parameters/pageNumber.yaml'
     - $ref: '../parameters/consumer.yaml'


### PR DESCRIPTION
Fixes a bug: adds missing primaryCode query parameter to `GET /academic-sessions`.