### PR TITLE
Fixes a bug with a filter in /courses/{courseId}/offerings

### DIFF
--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -16,12 +16,6 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
-    - name: modeOfStudy
-      in: query
-      description: Filter by modeOfStudy
-      required: false
-      schema:
-        $ref: '../enumerations/modeOfStudy.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v5/paths/CourseOfferingCollection.yaml
+++ b/v5/paths/CourseOfferingCollection.yaml
@@ -16,6 +16,12 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - name: modeOfDelivery
+      in: query
+      description: Filter by modeOfDelivery
+      required: false
+      schema:
+        $ref: '../enumerations/modesOfDelivery.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected


### PR DESCRIPTION
This PR fixes a bug in `GET /courses/{courseId}/offerings`. This request currently specifies a filter on the attribute `modeOfStudy`. Since v5.0 offerings no longer have the `modeOfStudy` attribute.

This PR removes the filter option from this request.