### PR TITLE
Fix typo in /programs `sort` param example.

### DIFF
--- a/v5/paths/ProgramCollection.yaml
+++ b/v5/paths/ProgramCollection.yaml
@@ -55,7 +55,7 @@ get:
             - -programId
             - -name
         default: [ name ]
-        sort:
+        example:
           - name
           - programId
   responses:


### PR DESCRIPTION
The 'example' attribute was mistakenly named 'sort'.