### PR TITLE
Add release Gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: release
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - "release *"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+      - name: Generate v4 bundle
+        run: npx @redocly/cli bundle v4/spec.yaml -d -o ooapiv4.yaml
+      - name: Generate v5 bundle
+        run: npx @redocly/cli bundle v5/spec.yaml -d -o ooapiv5.yaml
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ooapiv4.yaml
+            ooapiv5.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
     tags:
-      - "release *"
+      - "release-*"
 
 jobs:
   release:


### PR DESCRIPTION
This PR adds a Github Action that creates a GH release whenever a tag `release-*` is pushed to the repository. Since the OOAPI repository contains multiple versions (v1 - v5), tags indicating a specific OOAPI version do not seem logical. That's why I've chosen the `release-*` pattern for tags.

When the action runs, it setups node and uses the `@redocly/cli` tool to generate a bundle file for v4 and v5 and attaches them to the release.