### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: release
 
 on:
   push:
-    branches:
-      - 'master'
     tags:
       - "release-*"
 


### PR DESCRIPTION
This PR modifies the release GH action to only trigger on tags, otherwise each push on master will result in a failed action.