### PR TITLE
Add `explode: false` to all `sort` and `expand` query parameters

### DIFF
--- a/v5/paths/AcademicSessionInstance.yaml
+++ b/v5/paths/AcademicSessionInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to expand, separated by a comma
       required: false
       schema:

--- a/v5/paths/AssociationInstance.yaml
+++ b/v5/paths/AssociationInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to expand, separated by a comma
       required: false
       schema:

--- a/v5/paths/ComponentInstance.yaml
+++ b/v5/paths/ComponentInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to expand, separated by a comma
       required: false
       schema:

--- a/v5/paths/CourseInstance.yaml
+++ b/v5/paths/CourseInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to include, separated by a comma
       required: false
       schema:

--- a/v5/paths/EducationSpecificationInstance.yaml
+++ b/v5/paths/EducationSpecificationInstance.yaml
@@ -14,6 +14,7 @@ get:
     - $ref: '../parameters/returnTimelineOverrides.yaml'
     - name: expand
       in: query
+      explode: false
       description: Optional properties to include, separated by a comma
       required: false
       schema:

--- a/v5/paths/GroupInstance.yaml
+++ b/v5/paths/GroupInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to expand, separated by a comma
       required: false
       schema:

--- a/v5/paths/NewsItemInstance.yaml
+++ b/v5/paths/NewsItemInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to include, separated by a comma
       required: false
       schema:

--- a/v5/paths/OfferingAssociationCollection.yaml
+++ b/v5/paths/OfferingAssociationCollection.yaml
@@ -44,6 +44,7 @@ get:
         $ref: '../enumerations/resultState.yaml'
     - name: sort
       in: query
+      explode: false
       description: 'Sort by one or more attributes, the default is ascending. Prefixing the attribute with a minus sign `-` allows for descending sort. Examples: [ATTR | -ATTR | ATTR1,-ATTR2]'
       required: false
       schema:

--- a/v5/paths/OfferingInstance.yaml
+++ b/v5/paths/OfferingInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to expand, separated by a comma
       required: false
       schema:

--- a/v5/paths/OrganizationInstance.yaml
+++ b/v5/paths/OrganizationInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to expand, separated by a comma
       required: false
       schema:

--- a/v5/paths/ProgramInstance.yaml
+++ b/v5/paths/ProgramInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to include, separated by a comma
       required: false
       schema:

--- a/v5/paths/RoomInstance.yaml
+++ b/v5/paths/RoomInstance.yaml
@@ -13,6 +13,7 @@ get:
         format: uuid
     - name: expand
       in: query
+      explode: false
       description: Optional properties to expand, separated by a comma
       required: false
       schema:


### PR DESCRIPTION
This PR makes sure all `sort` and `expand` query parameter serialization matches the description and documentation by adding `explode: false`.