### PR TITLE
Add a sentence clarifying id-persistence to all identifiers.

### DIFF
--- a/v5/schemas/AcademicSession.yaml
+++ b/v5/schemas/AcademicSession.yaml
@@ -10,7 +10,7 @@ required:
 properties:
   academicSessionId:
     type: string
-    description: Unique id for this academic session
+    description: Unique id for this academic session. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-426614174000
     readOnly: true

--- a/v5/schemas/AssociationId.yaml
+++ b/v5/schemas/AssociationId.yaml
@@ -2,7 +2,7 @@ type: object
 properties:
   associationId:
     type: string
-    description: Unique id of this association
+    description: Unique id of this association.  This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-426614174000
     readOnly: true

--- a/v5/schemas/Building.yaml
+++ b/v5/schemas/Building.yaml
@@ -8,7 +8,7 @@ required:
 properties:
   buildingId:
     type: string
-    description: Unique id of this building
+    description: Unique id of this building. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-331214174000
   primaryCode:

--- a/v5/schemas/Component.yaml
+++ b/v5/schemas/Component.yaml
@@ -10,7 +10,7 @@ required:
 properties:
   componentId:
     type: string
-    description: Unique id of this component
+    description: Unique id of this component. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-426614174000
     readOnly: true

--- a/v5/schemas/CourseId.yaml
+++ b/v5/schemas/CourseId.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   courseId:
     type: string
-    description: Unique id of this course
+    description: Unique id of this course. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-426614174000
     readOnly: true

--- a/v5/schemas/Group.yaml
+++ b/v5/schemas/Group.yaml
@@ -11,7 +11,7 @@ required:
 properties:
   groupId:
     type: string
-    description: Unique id for this group
+    description: Unique id for this group. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-426614174000
   primaryCode:

--- a/v5/schemas/NewsFeed.yaml
+++ b/v5/schemas/NewsFeed.yaml
@@ -8,7 +8,7 @@ required:
 properties:
   newsFeedId:
     type: string
-    description: Unique id for this news feed
+    description: Unique id for this news feed. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-134564174222
   newsFeedType:

--- a/v5/schemas/NewsItem.yaml
+++ b/v5/schemas/NewsItem.yaml
@@ -6,7 +6,7 @@ required:
 properties:
   newsItemId:
     type: string
-    description: Unique id for this news item
+    description: Unique id for this news item. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-122564174000
   newsItemType:

--- a/v5/schemas/OfferingId.yaml
+++ b/v5/schemas/OfferingId.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   offeringId:
     type: string
-    description: Unique id of this offering
+    description: Unique id of this offering. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-134564174000
     readOnly: true

--- a/v5/schemas/Organization.yaml
+++ b/v5/schemas/Organization.yaml
@@ -9,7 +9,7 @@ required:
 properties:
   organizationId:
     type: string
-    description: Unique id of this organization
+    description: Unique id of this organization. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-123514174000
     readOnly: true

--- a/v5/schemas/PersonId.yaml
+++ b/v5/schemas/PersonId.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   personId:
     type: string
-    description: Unique id of this person
+    description: Unique id of this person. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-426614174000
 required:

--- a/v5/schemas/ProgramId.yaml
+++ b/v5/schemas/ProgramId.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   programId:
     type: string
-    description: Unique id for this program
+    description: Unique id for this program. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-426614174000
     readOnly: true

--- a/v5/schemas/Room.yaml
+++ b/v5/schemas/Room.yaml
@@ -8,7 +8,7 @@ required:
 properties:
   roomId:
     type: string
-    description: Unique id for this room
+    description: Unique id for this room. This id should be a stable (persistent) uuid, always pointing to the same resource.
     format: uuid
     example: 123e4567-e89b-12d3-a456-332114174000
   primaryCode:


### PR DESCRIPTION
This PR adds a sentence to all the `*Id` descriptions clarifying that identifiers should be persistent uuid's, always pointing to the same resource.

This information was already present in the documentation: https://openonderwijsapi.nl/#/technical/identifiers.

This PR fixes #123 