### PR TITLE
Fix bugs in the spec

### DIFF
--- a/v5/schemas/ComponentOffering.yaml
+++ b/v5/schemas/ComponentOffering.yaml
@@ -67,14 +67,4 @@ allOf:
           - $ref: './Identifier.yaml'
             title: organizationId
           - $ref: './Organization.yaml'
-            title: Organization object     
-      academicSession:
-        description: |
-          The academicsession during which this componentoffering takes place. [`expandable`](#tag/academic_session_model)
-          By default only the `academicSessionId` (a string) is returned. If the client requested an expansion of `academicSession` the full academicsession object should be returned.
-        oneOf:
-          - $ref: './Identifier.yaml'
-            title: academicSessionId
-          - $ref: './AcademicSession.yaml'
-            title: AcademicSession object
-
+            title: Organization object

--- a/v5/schemas/CourseOffering.yaml
+++ b/v5/schemas/CourseOffering.yaml
@@ -71,15 +71,7 @@ allOf:
             title: organizationId
           - $ref: './Organization.yaml'
             title: Organization object     
-      academicSession:
-        description: |
-          The academicsession during which this courseoffering takes place. [`expandable`](#tag/academic_session_model)
-          By default only the `academicSessionId` (a string) is returned. If the client requested an expansion of `academicSession` the full academicsession object should be returned.
-        oneOf:
-          - $ref: './Identifier.yaml'
-            title: academicSessionId
-          - $ref: './AcademicSession.yaml'
-            title: AcademicSession object
+
 
 
 

--- a/v5/schemas/OfferingProperties.yaml
+++ b/v5/schemas/OfferingProperties.yaml
@@ -24,7 +24,14 @@ properties:
       - component
     example: component
   academicSession:
-    $ref: './AcademicSession.yaml'
+    description: |
+      The academicsession during which this courseoffering takes place. [`expandable`](#tag/academic_session_model)
+      By default only the `academicSessionId` (a string) is returned. If the client requested an expansion of `academicSession` the full academicsession object should be returned.
+    oneOf:
+      - $ref: './Identifier.yaml'
+        title: academicSessionId
+      - $ref: './AcademicSession.yaml'
+        title: AcademicSession object
   name:
     type: array
     description: The name of this offering

--- a/v5/schemas/ProgramOffering.yaml
+++ b/v5/schemas/ProgramOffering.yaml
@@ -2,7 +2,6 @@ allOf:
   - $ref: './Offering.yaml'
   - type: object
     required:
-      - modeOfStudy
       - startDate
       - endDate
     properties:
@@ -62,13 +61,4 @@ allOf:
           - $ref: './Identifier.yaml'
             title: organizationId
           - $ref: './Organization.yaml'
-            title: Organization object     
-      academicSession:
-        description: |
-          The academicsession during which this programoffering takes place. [`expandable`](#tag/academic_session_model)
-          By default only the `academicSessionId` (a string) is returned. If the client requested an expansion of `academicSession` the full academicsession object should be returned.
-        oneOf:
-          - $ref: './Identifier.yaml'
-            title: academicSessionId
-          - $ref: './AcademicSession.yaml'
-            title: AcademicSession object
+            title: Organization object


### PR DESCRIPTION
This PR fixes two bug in the spec:

1. `modeOfStudy` is not an attribute in offerings (it used to be in v4), but it was required in ProgramOffering
2. ProgramOffering, CourseOffering and ProgramOffering all had a double reference to `academicSession`. This broke some validators. This PR removes one the references in each object.