### PR TITLE
Remove required modeOfStudy from CourseOffering

### DIFF
--- a/v5/schemas/CourseOffering.yaml
+++ b/v5/schemas/CourseOffering.yaml
@@ -2,7 +2,6 @@ allOf:
   - $ref: './Offering.yaml'
   - type: object
     required:
-      - modeOfStudy
       - startDate
       - endDate
     properties:


### PR DESCRIPTION
This PR removes the required attribute `modeOfStudy` from CourseOffering because this attribute is no longer an attribute in CourseOffering