### PR TITLE
#323 how to deal with no longer existing country codes

### DIFF
--- a/v6/schemas/Address.yaml
+++ b/v6/schemas/Address.yaml
@@ -31,9 +31,7 @@ properties:
     description: name of the city / locality
     example: Utrecht
   countryCode:
-    type: string
-    description: the country code according to [iso-3166-1-alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
-    example: NL
+    $ref: ./Country.yaml
   geolocation:
     type: object
     description: Geolocation of the entrance of this address (WGS84 coordinate reference system)

--- a/v6/schemas/Country.yaml
+++ b/v6/schemas/Country.yaml
@@ -1,0 +1,33 @@
+type: object
+description: >
+  An object indicating a country based on at least one iso-3166 code.
+  In situations where more than one iso-3166 code is provided the codes have address the same country.
+required:
+properties:
+  iso3166-1-alpha2:
+    type: string
+    minLength: 2
+    maxLength: 2
+    description: A country code based on https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+    example: NL
+  iso3166-1-alpha3:
+    type: string
+    minLength: 3
+    maxLength: 3
+    description: A country code based on https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+    example: NLD
+  iso3166-2:
+    type: string
+    minLength: 5
+    maxLength: 6
+    description: A country subdivision code based on https://en.wikipedia.org/wiki/ISO_3166-2
+    example: BQ-BO
+  iso3166-3:
+    type: string
+    minLength: 4
+    maxLength: 4
+    description: > 
+      A code for a country that no longer exists on https://en.wikipedia.org/wiki/ISO_3166-3
+      It is not adviced to use the original iso3166-1 for such a country since country codes
+      can get reassigned to new countries ones the original country code is officially obsolete.
+    example: ANHH

--- a/v6/schemas/Nationality.yaml
+++ b/v6/schemas/Nationality.yaml
@@ -1,0 +1,29 @@
+type: object
+description: >
+  An object indicating nationality based on at least one iso-3166 code.
+  In situations where more than one iso-3166 code is provided the codes have address the same country.
+required:
+properties:
+  iso3166-1-alpha2:
+    type: string
+    minLength: 2
+    maxLength: 2
+    description: A country code based on https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+    example: NL
+  iso3166-1-alpha3:
+    type: string
+    minLength: 3
+    maxLength: 3
+    description: A country code based on https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+    example: NLD
+  iso3166-3:
+    type: string
+    minLength: 4
+    maxLength: 4
+    description: > 
+      A nationality code for a country that no longer exists on https://en.wikipedia.org/wiki/ISO_3166-3
+      It is not adviced to use the original iso3166-1 for such a country since country codes
+      can get reassigned to new countries ones the original country code is officially obsolete. It is possible
+      that a person has a nationality of a country that does not exist anymore (after a country got split up like CZ and YU)\
+      and never applied for nationality of one of the new countries.
+    example: ANHH

--- a/v6/schemas/PersonProperties.yaml
+++ b/v6/schemas/PersonProperties.yaml
@@ -54,13 +54,9 @@ properties:
     description: The city of birth of this person
     example: Utrecht
   countryOfBirth:
-    type: string
-    description: The country of birth of this person the country code according to [iso-3166-1-alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
-    example: NL
+    $ref: ./Country.yaml
   nationality:
-    type: string
-    description: The nationality of this person the nationality according to https://gist.github.com/zspine/2365808
-    example: Dutch
+    $ref: ./Nationality.yaml
   dateOfNationality:
     type: string
     description: The date of nationality of this person, RFC3339 (full-date)


### PR DESCRIPTION
Implements #323 
Added country in the address properties to this PR to have a consistent method of describing countries.

Separate country and nationality properties files created since a country can be indicated by a subdivision (BQ-BO for Bonaire as part of Carribean Netherlands). However, this subdivision cannot exist as a nationality

