### PR TITLE
Minor grammar, fixes and additions

### DIFF
--- a/v6/enumerations/groupType.yaml
+++ b/v6/enumerations/groupType.yaml
@@ -3,7 +3,7 @@ description: |
   The type of this group
   - class: A collection of students jointly scheduled for/assigned to/carrying out educational activities
   - team: A collection of members of a team, either students, employees or mixed.
-  - group: A collection of students jointly scheduled for/assigned to/carrying out educational activities in a context not provide by a class
+  - group: A collection of students jointly scheduled for/assigned to/carrying out educational activities in a context not provided by a class
 enum:
   - class
   - team

--- a/v6/schemas/Country.yaml
+++ b/v6/schemas/Country.yaml
@@ -1,7 +1,7 @@
 type: object
 description: >
   An object indicating a country based on at least one iso-3166 code.
-  In situations where more than one iso-3166 code is provided the codes have address the same country.
+  In situations where more than one ISO-3166 code is provided, the codes must refer to the same country.
 properties:
   iso3166-1-alpha2:
     type: string
@@ -25,8 +25,8 @@ properties:
     type: string
     minLength: 4
     maxLength: 4
-    description: > 
-      A code for a country that no longer exists on https://en.wikipedia.org/wiki/ISO_3166-3
-      It is not adviced to use the original iso3166-1 for such a country since country codes
-      can get reassigned to new countries ones the original country code is officially obsolete.
+    description: |
+      A code for a country that no longer exists is listed on ISO 3166-3 (https://en.wikipedia.org/wiki/ISO_3166-3).
+      Implementations should refrain from using the original ISO 3166-1 code for such a country since country codes
+      can be reassigned to new countries once the original country code is officially declared obsolete.
     example: ANHH

--- a/v6/schemas/CourseOffering.yaml
+++ b/v6/schemas/CourseOffering.yaml
@@ -15,15 +15,15 @@ allOf:
         description: The moment on which this offering ends, RFC3339 (full-date)
         format: date
         example: 2019-10-23
-      enrollStartDate:
+      enrollStartDateTime:
         type: string
-        description: The first day on which a student can enroll for this course.
-        format: date
+        description: The moment from which a student can enroll for this component, RFC3339 (date-time).
+        format: date-time
         example: 2019-05-01
-      enrollEndDate:
+      enrollEndDateTime:
         type: string
-        description: The last day on which a student can enroll for this course.
-        format: date
+        description: The last moment to which a student can enroll for this component, RFC3339 (date-time).
+        format: date-time
         example: 2019-08-01
       flexibleEntryPeriodStart:
         type: string
@@ -54,7 +54,7 @@ allOf:
             title: Course object      
       programOfferings:
         description: |
-          An array of 0 or more programofferings where this courseoffering is related to. [`expandable`](#tag/program_offering_model)
+          An array of 0 or more programofferings that this courseoffering is related to. [`expandable`](#tag/program_offering_model)
           By default only the `programOfferingId` (a string) is returned. If the client requested an expansion of `programOffering` the full programOffering object should be returned.
         type: array
         items: 

--- a/v6/schemas/CourseProperties.yaml
+++ b/v6/schemas/CourseProperties.yaml
@@ -68,7 +68,7 @@ properties:
     items:
       oneOf:
       - $ref: './Identifier.yaml'
-        title: programId
+        title: learningOutcomeId
       - $ref: './LearningOutcome.yaml'
         title: LearningOutcome
   admissionRequirements:

--- a/v6/schemas/LearningComponentOffering.yaml
+++ b/v6/schemas/LearningComponentOffering.yaml
@@ -15,14 +15,14 @@ allOf:
         description: The moment on which this offering ends, RFC3339 (date-time)
         format: date-time
         example: 2020-12-16
-      enrollStartDate:
+      enrollStartDateTime:
         type: string
-        description: The first day on which a student can enroll for this course.
-        format: date
-      enrollEndDate:
+        description: The moment from which a student can enroll for this component, RFC3339 (date-time).
+        format: date-time
+      enrollEndDateTime:
         type: string
-        description: The last day on which a student can enroll for this course.
-        format: date
+        description: The last moment to which a student can enroll for this component, RFC3339 (date-time).
+        format: date-time
       resultWeight:
         type: integer
         description: The result weight of this offering

--- a/v6/schemas/ProgramOffering.yaml
+++ b/v6/schemas/ProgramOffering.yaml
@@ -15,15 +15,15 @@ allOf:
         description: The moment on which this offering ends, RFC3339 (full-date)
         format: date
         example: 2023-06-15
-      enrollStartDate:
+      enrollStartDateTime:
         type: string
-        description: The first day on which a student can enroll for this program.
-        format: date
+        description: The moment from which a student can enroll for this program, RFC3339 (date-time).
+        format: date-time
         example: 2019-05-01
-      enrollEndDate:
+      enrollEndDateTime:
         type: string
-        description: The last day on which a student can enroll for this program.
-        format: date
+        description: The last moment to which a student can enroll for this program, RFC3339 (date-time).
+        format: date-time
         example: 2019-08-01
       flexibleEntryPeriodStart:
         type: string

--- a/v6/schemas/TestComponentOffering.yaml
+++ b/v6/schemas/TestComponentOffering.yaml
@@ -15,14 +15,14 @@ allOf:
         description: The moment on which this offering ends, RFC3339 (date-time)
         format: date-time
         example: 2020-12-16
-      enrollStartDate:
+      enrollStartDateTime:
         type: string
-        description: The first day on which a student can enroll for this course.
-        format: date
-      enrollEndDate:
+        description: The moment from which a student can enroll for this component, RFC3339 (date-time).
+        format: date-time
+      enrollEndDateTime:
         type: string
-        description: The last day on which a student can enroll for this course.
-        format: date
+        description: The last moment to which a student can enroll for this component, RFC3339 (date-time).
+        format: date-time
       resultWeight:
         type: integer
         description: The result weight of this offering

--- a/v6/spec.yaml
+++ b/v6/spec.yaml
@@ -138,22 +138,34 @@ tags:
     x-displayName: ProgramOffering
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/ProgramOffering" />
+  - name: program_offering_association_model
+    x-displayName: ProgramOfferingAssociation
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/ProgramOfferingAssociation" />
   - name: course_offering_model
     x-displayName: CourseOffering
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/CourseOffering" />
+  - name: course_offering_association_model
+    x-displayName: CourseOfferingAssociation
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/CourseOfferingAssociation" />
   - name: learning_component_offering_model
     x-displayName: LearningComponentOffering
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/LearningComponentOffering" />
+  - name: learning_component_offering_association_model
+    x-displayName: LearningComponentOfferingAssociation
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/LearningComponentOfferingAssociation" />
   - name: test_component_offering_model
     x-displayName: TestComponentOffering
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/TestComponentOffering" />
-  - name: association_model
-    x-displayName: Association
+  - name: test_component_offering_association_model
+    x-displayName: TestComponentOfferingAssocation
     description: |
-      <SchemaDefinition schemaRef="#/components/schemas/Association" />
+      <SchemaDefinition schemaRef="#/components/schemas/TestComponentOfferingAssociation" />
   - name: person_model
     x-displayName: Person
     description: |
@@ -162,6 +174,10 @@ tags:
     x-displayName: Group
     description: |
       <SchemaDefinition schemaRef="#/components/schemas/Group" />
+  - name: membership_model
+    x-displayName: Membership
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/Membership" />
   - name: academic_session_model
     x-displayName: AcademicSession
     description: |
@@ -209,21 +225,25 @@ x-tagGroups:
       - service_model
       - learning_outcome_model
       - academic_session_model
-      - association_model
       - building_model
       - course_model
       - course_offering_model
+      - course_offering_association_model
       - learning_component_model
       - learning_component_offering_model
+      - learning_component_offering_association_model
       - test_component_model
       - test_component_offering_model
+      - test_component_offering_association_model
       - group_model
+      - membership_model
       - news_feed_model
       - news_item_model
       - organization_model
       - person_model
       - program_model
       - program_offering_model
+      - program_offering_association_model
       - learning_outcome_model
       - room_model
 
@@ -248,14 +268,22 @@ components:
       $ref: schemas/TestComponent.yaml
     LearningComponentOffering:
       $ref: schemas/LearningComponentOffering.yaml
+    LearningComponentOfferingAssociation:
+      $ref: schemas/LearningComponentOfferingAssociation.yaml
     TestComponentOffering:
       $ref: schemas/TestComponentOffering.yaml
+    TestComponentOfferingAssociation:
+      $ref: schemas/TestComponentOfferingAssociation.yaml
     Course:
       $ref: schemas/Course.yaml
     CourseOffering:
       $ref: schemas/CourseOffering.yaml
+    CourseOfferingAssociation:
+      $ref: schemas/CourseOfferingAssociation.yaml
     Group:
       $ref: schemas/Group.yaml
+    Membership:
+      $ref: schemas/Membership.yaml
     LearningOutcome:
       $ref: schemas/LearningOutcome.yaml  
     NewsFeed:
@@ -274,12 +302,6 @@ components:
       $ref: schemas/Room.yaml
     ProgramOfferingAssociation:
       $ref: schemas/ProgramOfferingAssociation.yaml
-    CourseOfferingAssociation:
-      $ref: schemas/CourseOfferingAssociation.yaml
-    LearningComponentOfferingAssociation:
-      $ref: schemas/LearningComponentOfferingAssociation.yaml
-    TestComponentOfferingAssociation:
-      $ref: schemas/TestComponentOfferingAssociation.yaml
 
 paths: {}
   # /:


### PR DESCRIPTION
This PR contains some minor grammar changes and other small fixes.

One change that I do want to mention is the change `enrollStartDate` and `enrollEndDate` to be date-times. In eduXchange we now have a consumer atrributes `enrollStartTime and `enrollEndTime` which we have to append to the dates which is really clunky. In practice, enrollment periods are specified with times, not just dates.