### PR TITLE
Turn teachingLanguage into an array

### DIFF
--- a/v6/schemas/CourseProperties.yaml
+++ b/v6/schemas/CourseProperties.yaml
@@ -56,7 +56,7 @@ properties:
     minItems: 1
     items:
       type: string
-      description:
+      description: A string describing the main teaching language, should be a three-letter language code as specified by ISO 639-2.
       minLength: 3
       maxLength: 3
       pattern: "^[a-z]{3}$"

--- a/v6/schemas/CourseProperties.yaml
+++ b/v6/schemas/CourseProperties.yaml
@@ -4,7 +4,7 @@ required:
   - name
   - abbreviation
   - description
-  - teachingLanguage
+  - teachingLanguages
   - level
   - primaryCode
 properties:
@@ -50,13 +50,17 @@ properties:
     example:
     - language: en-GB
       value: 'As with all empirical sciences, to assure valid outcomes, HCI studies heavily rely on research methods and statistics. This holds for the design of user interfaces, personalized recommender systems, and interaction paradigms for the internet of things. This course prepares you to do so by learning you to collect data, design experiments, and analyze the results. By the end of the course, you will have a detailed understanding of how to select and apply quantitative research methods and analysis to address virtually all HCI challenges. Quantitative research and data analysis will be taught in the context of state-of-the-art HCI challenges. Lectures will be alternated with hands-on learning, including work with predefined datasets (e.g., addressing facial features, cognitive load, and emotion). Additionally, students will set up their own research (e.g., using eye tracking). Data processing and analysis will be executed using R.'
-  teachingLanguage:
-    type: string
-    description: The (primary) teaching language in which this course is given, should be a three-letter language code as specified by ISO 639-2.
-    minLength: 3
-    maxLength: 3
-    pattern: "^[a-z]{3}$"
-    example: nld
+  teachingLanguages:
+    type: array
+    description:  The languages in which this course is given, should be three-letter language codes as specified by ISO 639-2. A student should be reasonably proficient in each language to be able to follow the course.
+    minItems: 1
+    items:
+      type: string
+      description:
+      minLength: 3
+      maxLength: 3
+      pattern: "^[a-z]{3}$"
+      example: nld
   fieldsOfStudy:
     type: string
     description: Field(s) of study (e.g. ISCED-F) (http://uis.unesco.org/sites/default/files/documents/isced-fields-of-education-and-training-2013-en.pdf.

--- a/v6/schemas/LearningComponent.yaml
+++ b/v6/schemas/LearningComponent.yaml
@@ -4,7 +4,7 @@ required:
   - componentId
   - componentType
   - name
-  - teachingLanguage
+  - teachingLanguages
   - abbreviation
   - primaryCode
 properties:
@@ -70,13 +70,17 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
-  teachingLanguage:
-    type: string
-    description: The (primary) teaching language in which this component is given, should be a three-letter language code as specified by ISO 639-2.
-    minLength: 3
-    maxLength: 3
-    pattern: "^[a-z]{3}$"
-    example: nld
+  teachingLanguages:
+    type: array
+    description:  The languages in which this learning component is given, should be three-letter language codes as specified by ISO 639-2. A student should be reasonably proficient in each language to be able to follow the learning component.
+    minItems: 1
+    items:
+      type: string
+      description:
+      minLength: 3
+      maxLength: 3
+      pattern: "^[a-z]{3}$"
+      example: nld
   learningOutcomes:
     description: Related Learning Outcomes to this learning component. This object is [`expandable`](#tag/learningoucome_model)
     type: array

--- a/v6/schemas/LearningComponent.yaml
+++ b/v6/schemas/LearningComponent.yaml
@@ -76,7 +76,7 @@ properties:
     minItems: 1
     items:
       type: string
-      description:
+      description: A string describing the main teaching language, should be a three-letter language code as specified by ISO 639-2.
       minLength: 3
       maxLength: 3
       pattern: "^[a-z]{3}$"

--- a/v6/schemas/OfferingProperties.yaml
+++ b/v6/schemas/OfferingProperties.yaml
@@ -71,7 +71,7 @@ properties:
     minItems: 1
     items:
       type: string
-      description:
+      description: A string describing the main teaching language, should be a three-letter language code as specified by ISO 639-2.
       minLength: 3
       maxLength: 3
       pattern: "^[a-z]{3}$"

--- a/v6/schemas/OfferingProperties.yaml
+++ b/v6/schemas/OfferingProperties.yaml
@@ -5,7 +5,7 @@ required:
   - offeringType
   - name
   - description
-  - teachingLanguage
+  - teachingLanguages
   - resultExpected
 properties:
   primaryCode:
@@ -65,13 +65,17 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
-  teachingLanguage:
-    type: string
-    description: The (primary) teaching language in which this offering is given, should be a three-letter language code as specified by ISO 639-2.
-    minLength: 3
-    maxLength: 3
-    pattern: "^[a-z]{3}$"
-    example: nld
+  teachingLanguages:
+    type: array
+    description:  The languages in which this course is given, should be three-letter language codes as specified by ISO 639-2. A student should be reasonably proficient in each language to be able to follow the offering.
+    minItems: 1
+    items:
+      type: string
+      description:
+      minLength: 3
+      maxLength: 3
+      pattern: "^[a-z]{3}$"
+      example: nld
   modeOfDelivery:
     $ref: '../enumerations/modesOfDelivery.yaml'
   maxNumberStudents:

--- a/v6/schemas/ProgramProperties.yaml
+++ b/v6/schemas/ProgramProperties.yaml
@@ -6,7 +6,7 @@ required:
   - abbreviation
   - description
   - primaryCode
-  - teachingLanguage
+  - teachingLanguages
 properties:
   primaryCode:
     description: The primary human readable identifier for the program. This is often the source identifier as defined by the institution.
@@ -40,13 +40,17 @@ properties:
     example:
     - language: en-GB
       value: The study of life
-  teachingLanguage:
-    type: string
-    description: The (primary) teaching language in which this program is given, should be a three-letter language code as specified by ISO 639-2.
-    minLength: 3
-    maxLength: 3
-    pattern: "^[a-z]{3}$"
-    example: nld
+  teachingLanguages:
+    type: array
+    description:  The languages in which this program is given, should be three-letter language codes as specified by ISO 639-2. A student should be reasonably proficient in each language to be able to follow the program.
+    minItems: 1
+    items:
+      type: string
+      description:
+      minLength: 3
+      maxLength: 3
+      pattern: "^[a-z]{3}$"
+      example: nld
   studyLoad:
     type: array
     items:

--- a/v6/schemas/ProgramProperties.yaml
+++ b/v6/schemas/ProgramProperties.yaml
@@ -46,7 +46,7 @@ properties:
     minItems: 1
     items:
       type: string
-      description:
+      description: A string describing the main teaching language, should be a three-letter language code as specified by ISO 639-2.
       minLength: 3
       maxLength: 3
       pattern: "^[a-z]{3}$"

--- a/v6/schemas/TestComponent.yaml
+++ b/v6/schemas/TestComponent.yaml
@@ -4,7 +4,7 @@ required:
   - componentId
   - componentType
   - name
-  - teachingLanguage
+  - teachingLanguages
   - abbreviation
   - primaryCode
 properties:
@@ -70,13 +70,17 @@ properties:
               Select an appropriate sampling method (e.g., stratified)
               Perform parametric tests (e.g., repeated measures (M)ANOVA)
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
-  teachingLanguage:
-    type: string
-    description: The (primary) teaching language in which this component is given, should be a three-letter language code as specified by ISO 639-2.
-    minLength: 3
-    maxLength: 3
-    pattern: "^[a-z]{3}$"
-    example: nld
+  teachingLanguages:
+    type: array
+    description:  The languages in which this test component is given, should be three-letter language codes as specified by ISO 639-2. A student should be reasonably proficient in each language to be able to follow the test component.
+    minItems: 1
+    items:
+      type: string
+      description:
+      minLength: 3
+      maxLength: 3
+      pattern: "^[a-z]{3}$"
+      example: nld
   learningOutcomes:
     description: Related Learning Outcomes to this test component. This object is [`expandable`](#tag/learningoucome_model)
     type: array

--- a/v6/schemas/TestComponent.yaml
+++ b/v6/schemas/TestComponent.yaml
@@ -76,7 +76,7 @@ properties:
     minItems: 1
     items:
       type: string
-      description:
+      description: A string describing the main teaching language, should be a three-letter language code as specified by ISO 639-2.
       minLength: 3
       maxLength: 3
       pattern: "^[a-z]{3}$"


### PR DESCRIPTION
This PR turns `teachingLanguage` into an array `teachingLanguages`. Rationale: this is a common request we get from institutions using the OOAPI. In The Netherlands, also DUO is changing "voertaal" to be an array.