### PR TITLE
V5 specification: Fix rio offering modeOfDelivery example from string to array

### DIFF
--- a/v5/consumers/RIO/V1/examples/Offering.yaml
+++ b/v5/consumers/RIO/V1/examples/Offering.yaml
@@ -2,4 +2,4 @@
   explanationRequiredPermission: Toestemming is vereist omdat we daarom vragen.
   requiredPermissionRegistration: yes
   registrationStatus: open
-  modeOfDelivery: coaching
+  modeOfDelivery: ["coaching"]


### PR DESCRIPTION
offering consumer rio modeOfDelivery example needs to be an array, not string.
