### PR TITLE
Add a github action to check if a PR changed the CHANGELOG.md file

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,15 @@
+name: Check Changelog
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - 6.0
+      - master
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: tarides/changelog-check-action@v2
+        with:
+          changelog: CHANGELOG.md

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -10,6 +10,6 @@ jobs:
     name: Check Changelog Action
     runs-on: ubuntu-22.04
     steps:
-      - uses: tarides/changelog-check-action@v2
+      - uses: tarides/changelog-check-action@v3
         with:
           changelog: CHANGELOG.md


### PR DESCRIPTION
This PR adds a github action to verify that a PR updated the CHANGELOG.md file.

This check can be skipped by adding a label to the PR: `no changelog`