### PR TITLE
Udate to en_GB, including some enums

### DIFF
--- a/v6/enumerations/ICERelationType.yaml
+++ b/v6/enumerations/ICERelationType.yaml
@@ -1,9 +1,12 @@
 type: string
 description: |
-  Type of relation between the person and their In Case of Emergency (ICE) contact:
-  - partner: spouse or life partner
-  - parent: biological, adoptive, or legal parent
-  - other: other type of relationship (e.g. sibling, friend, neighbor)
+  The type of relationship between the person and their In Case of Emergency (ICE) contact:
+
+  - partner: Spouse or life partner
+  - parent: Biological, adoptive, or legal parent
+  - other: Any other type of relationship (e.g. sibling, friend, neighbour)
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - partner
   - parent

--- a/v6/enumerations/academicSessionType.yaml
+++ b/v6/enumerations/academicSessionType.yaml
@@ -1,14 +1,15 @@
 type: string
 description: |
-  The type of this Academic Session This is an *extensible enumeration*.
-  - academic_year: academic year
-  - semester: semester, typically there are two semesters per academic year
-  - trimester: trimester, typically there are three trimesters per academic year
-  - quarter: quarter, typically there are four quarters per academic year
-  - testing_period: a period in which tests take place
-  - period: any other period in an academic year
+  The type of this Academic Session. This is an *extensible enumeration*.
 
-  Implementations are allowed to add additional values to those above, as long as they do not overlap in definition to existing values.
+  - academic_year: Academic year
+  - semester: Semester, typically comprising two terms per academic year
+  - trimester: Trimester, typically comprising three terms per academic year
+  - quarter: Quarter, typically comprising four terms per academic year
+  - testing_period: A period during which tests take place
+  - period: Any other period within an academic year
+
+  Implementations may add further values beyond those listed above, provided they do not overlap in definition with existing values.
 x-ooapi-extensible-enum:
   - academic_year
   - semester

--- a/v6/enumerations/addressType.yaml
+++ b/v6/enumerations/addressType.yaml
@@ -1,15 +1,18 @@
 type: string
 description: |
   The type of address, indicating its intended use:
-  - postal: used for receiving mail
-  - visit: used for physical visits
-  - deliveries: used for deliveries
-  - billing: used for invoicing and billing purposes
-  - teaching: the location where educational activities are held
+    
+  - postal: Used for receiving post
+  - visit: Used for physical visits
+  - deliveries: Used for deliveries
+  - invoicing: Used for invoicing purposes
+  - teaching: The location where educational activities take place
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - postal
   - visit
   - deliveries
-  - billing
+  - invoicing
   - teaching
 example: postal

--- a/v6/enumerations/associationAttendance.yaml
+++ b/v6/enumerations/associationAttendance.yaml
@@ -1,11 +1,14 @@
 type: string
 description: |
   The attendance status of an individual's association with an offering:
-  - not_known: attendance status is unknown or unrecorded
-  - not_started: attendance has not yet begun
-  - not_finished: attendance has begun but not completed
-  - present: individual attended as expected
-  - not_present: individual did not attend
+
+  - not_known: Attendance status is unknown or unrecorded
+  - not_started: Attendance has not yet started
+  - not_finished: Attendance has started but not been completed
+  - present: The individual attended as expected
+  - not_present: The individual did not attend
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - not_known
   - not_started

--- a/v6/enumerations/associationRole.yaml
+++ b/v6/enumerations/associationRole.yaml
@@ -1,13 +1,16 @@
 type: string
 description: |
   The role of the person associated with the offering:
-  - student: enrolled participant in the offering
-  - lecturer: delivers or leads the teaching content
-  - teaching_assistant: supports the lecturer in teaching activities
-  - coordinator: responsible for organizational or administrative aspects
-  - invigilator: supervises exams or assessments
-  - assessor: evaluates student performance or work
-  - guest: external participant with a non-standard role
+    
+  - student: Enrolled participant in the offering
+  - lecturer: Delivers lectures or leads teaching
+  - teaching_assistant: Supports the lecturer in teaching activities
+  - coordinator: Responsible for organisational or administrative aspects
+  - invigilator: Supervises examinations or assessments
+  - assessor: Evaluates student performance or work
+  - guest: External participant with an atypical role
+    
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - student
   - lecturer

--- a/v6/enumerations/associationState.yaml
+++ b/v6/enumerations/associationState.yaml
@@ -1,15 +1,18 @@
 type: string
 description: |
-  The state of this association
-  - pending: A student wants to enroll, but the enrollment has not yet been confirmed/accepted/processed
-  - canceled: The association has been canceled, for example by the student or the institution
-  - denied: The student was denied enrollment, for example because the student does not meet the requirements
-  - associated: The association has been confirmed/accepted/processed, the student is enrolled
+  The state of this association:
+    
+  - pending: A student has requested enrolment, but it has not yet been confirmed, accepted or processed
+  - cancelled: The association has been cancelled, for example by the student or the institution
+  - denied: The student was denied enrolment, for example because they did not meet the requirements
+  - associated: The association has been confirmed, accepted or processed; the student is enrolled
   - queued: The association is in a queue, for example because the course is full
   - finished: The association has ended, for example because the course has ended or the student has completed the course
+    
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - pending
-  - canceled
+  - cancelled
   - denied
   - associated
   - queued

--- a/v6/enumerations/codeType.yaml
+++ b/v6/enumerations/codeType.yaml
@@ -1,43 +1,43 @@
 type: string
 description: |
-  The code/identifier type. 
-  
-  This is an *extensible enumeration*. Use `x-` to prefix custom values
-  
+  The type of code or identifier.
+
   The predefined values are:
-    - `brin`: The registration number for a Dutch educational institution that is issued by the Dutch Ministry of Education, Culture and Science
-    - `croho_crebo_code`: programs with a CREBO and CROHO number are accredited by the Dutch Ministry of Education, Culture and Science (OCW)
-    - `program_code`: Identifier for the program (collection of courses)
-    - `component_code`: The code for a component (part of a course)
-    - `offering_code`: The code to identify a specific offering (program, course or component offering)
-    - `organization_id`: The identifier for the organization
-    - `building_id`: The number or code to identify a building
-    - `bag_id`: The identification of a building as it is known in the Dutch Building Administration (BAG)
-    - `room_code`: The code for a room
-    - `system_id`: Identifier assigned to an entity in context of a specific system
-    - `product_id`: Identifier assigned to a specific product
-    - `national_identity_number`: Identifier assigned by the governement of the person. e.g. a social security number in the USA
-    - `student_number`: Identifier for the student
-    - `studielink_number`: Identifier for the person as determined by the dutch centralized program enrollment system Studielink
+    
+    - `brin`: The registration number of a Dutch educational institution, as issued by the Dutch Ministry of Education, Culture and Science (OCW)
+    - `croho_crebo_code`: Programmes with a CREBO or CROHO number accredited by the Dutch Ministry of Education, Culture and Science (OCW)
+    - `programme_code`: Identifier for a programme (collection of courses)
+    - `component_code`: Code for a component (part of a course)
+    - `offering_code`: Code used to identify a specific offering (programme, course or component offering)
+    - `organisation_id`: Identifier for the organisation
+    - `building_id`: Code used to identify a building
+    - `bag_id`: Identifier for a building as registered in the Dutch Building and Address Registry (BAG)
+    - `room_code`: Code used to identify a room
+    - `system_id`: Identifier assigned within the context of a specific system
+    - `product_id`: Identifier for a specific product
+    - `national_identity_number`: Identifier assigned by a government to a person (e.g. national insurance number in the UK, or personnummer in Sweden)    - `student_number`: Identifier for a student
+    - `studielink_number`: Identifier assigned to a person by the Dutch centralised enrolment system Studielink
     - `esi`: European Student Identifier
-    - `username`: The name of a user
-    - `account_id`: Identifier assigned to a specific account
-    - `email_adress`: An email address
-    - `group_code`: The identifier for a group (of persons)
-    - `group_type_code`: The identifier for a type of group
-    - `isbn`: International Standard Book Number that serve as product identifiers for Books
-    - `issn`: International Standard Book Number that serve as product identifiers for periodicals
+    - `username`: The user's login name
+    - `account_id`: Identifier for a specific account
+    - `email_address`: An email address
+    - `group_code`: Identifier for a group (of people)
+    - `group_type_code`: Identifier for the type of group
+    - `isbn`: International Standard Book Number (used to identify books)
+    - `issn`: International Standard Serial Number (used to identify periodicals)
     - `orcid`: Open Researcher and Contributor ID
-    - `uuid`: A universally unique identifier
-    - `schac_home`: Home organization using the domain name of the organization
-    - `identifier`: Generic Identifier
+    - `uuid`: Universally unique identifier
+    - `schac_home`: Home organisation, represented by its domain name
+    - `identifier`: Generic identifier
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - brin
   - croho_crebo_code
-  - program_code
+  - programme_code
   - component_code
   - offering_code
-  - organization_id
+  - organisation_id
   - building_id
   - bag_id
   - room_code
@@ -51,6 +51,7 @@ x-ooapi-extensible-enum:
   - account_id
   - email_address
   - group_code
+  - group_type_code
   - isbn
   - issn
   - orcid

--- a/v6/enumerations/componentState.yaml
+++ b/v6/enumerations/componentState.yaml
@@ -1,13 +1,16 @@
 type: string
 description: |
   The state of this component or offering:
-  - concept: not yet finalized or published
-  - canceled: withdrawn and no longer available
+    
+  - concept: not yet finalised or published
+  - cancelled: withdrawn and no longer available
   - active: currently available and in use
-  - inactive: no longer in use, but not canceled
+  - inactive: no longer in use, but not cancelled
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - concept
-  - canceled
+  - cancelled
   - active
   - inactive
 example: active

--- a/v6/enumerations/costType.yaml
+++ b/v6/enumerations/costType.yaml
@@ -1,13 +1,14 @@
 type: string
 description: |
-  The type of the cost. This is an *extensible enumeration*.
+  The type of cost. This is an *extensible enumeration*.
 
-  The following values have been defined in the specification:
-    - stap_eligible: the costs that a student can get STAP subsidy for
-    - total_costs: the total costs that a student is to pay to follow this offering
-  
-  Implementations are allowed to add additional values to those above, as long as they do not overlap in definition to existing values.
+  The following values are defined in the specification:
+    
+    - stap_eligible: costs for which a student may receive STAP funding
+    - total_costs: the total amount a student is required to pay to participate in this offering
+
+  Implementations may add additional values beyond those listed above, provided they do not overlap in meaning with existing values.
 x-ooapi-extensible-enum:
   - stap_eligible
   - total_costs
-example: total costs
+example: total_costs

--- a/v6/enumerations/documentType.yaml
+++ b/v6/enumerations/documentType.yaml
@@ -1,17 +1,20 @@
 type: string
 description: |
-  The type of a documents:
-    - additional_document: e.g. to add additional information
-    - assessment_form: A form that is used to assess a test
-    - assessment_model: Formal description on how a test is assessed
-    - assignment: Description on what is expected from a student e.g. to hand in a paper
-    - attendance_report: A report that contains information on the attendance of a student for a course or test
-    - handed_in_document: A document that is handed in by the student
-    - instructions: Instructions for the student on how to enroll for a course or how to make a test
-    - plagiarism_report: A report that containts (potential) plagiarism info on e.g. a handed in document
-    - session_report: A report that contains information on a session, e.g. an academic session, a course or a test session
-    - test_made: The test including all the answers made by the student
-    - other: Other types of documents that are not listed above
+  The type of document:
+
+    - additional_document: Used to provide supplementary information
+    - assessment_form: A form used to assess a test
+    - assessment_model: A formal description of how a test is assessed
+    - assignment: A description of what is expected from a student, e.g. to submit a paper
+    - attendance_report: A report containing information on a student’s attendance for a course or test
+    - handed_in_document: A document submitted by the student
+    - instructions: Instructions for the student on how to enrol in a course or take a test
+    - plagiarism_report: A report containing information on (potential) plagiarism, e.g. in a submitted document
+    - session_report: A report containing information on a session, e.g. an academic session, course, or test session
+    - test_made: The completed test, including all answers provided by the student
+    - other: Any other type of document not listed above
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - additional_document
   - assessment_form

--- a/v6/enumerations/formalDocument.yaml
+++ b/v6/enumerations/formalDocument.yaml
@@ -1,11 +1,14 @@
 type: string
 description: |
-  The type of formal document obtained after completion of the education:
-  - diploma: official qualification awarded upon graduation
-  - certificate: formal recognition of participation or achievement
-  - no_official_document: no official document is issued
-  - testimonial: written statement attesting to attendance or performance
-  - school_advice: educational recommendation or guidance issued by the school
+  The type of formal document obtained upon completion of an educational programme:
+
+    - diploma: An official qualification awarded upon graduation
+    - certificate: A formal recognition of participation or achievement
+    - no_official_document: No official document is issued
+    - testimonial: A written statement confirming attendance or performance
+    - school_advice: Educational recommendation or guidance issued by the school
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - diploma
   - certificate

--- a/v6/enumerations/gender.yaml
+++ b/v6/enumerations/gender.yaml
@@ -1,13 +1,14 @@
 type: string
 description: |
-  The gender of this person, based on international education and data interoperability standards.
-  The values are informed by practices from agencies such as:
+  The gender of this person, based on international standards for education and data interoperability.
+
+  The values follow practices from agencies such as:
   - European Commission (EULF, INSPIRE, GeoDCAT-AP)
   - Edustandaard, EUNIS
   
   - m: male
   - f: female
-  - x: non-binary or gender diverse, officially registered
+  - x: non-binary or gender-diverse, officially registered
   - o: other gender identity, not officially classified as m/f/x
   - u: unknown or not registered
   - n: not applicable, e.g. for non-person entities or gender-irrelevant use cases

--- a/v6/enumerations/groupType.yaml
+++ b/v6/enumerations/groupType.yaml
@@ -1,9 +1,12 @@
 type: string
 description: |
-  The type of this group
-  - class: A collection of students jointly scheduled for/assigned to/carrying out educational activities
-  - team: A collection of members of a team, either students, employees or mixed.
-  - group: A collection of students jointly scheduled for/assigned to/carrying out educational activities in a context not provided by a class
+  The type of this group:
+
+  - class: A group of students jointly scheduled for, assigned to, or engaged in educational activities
+  - team: A group composed of members of a team, which may consist of students, staff, or a mix of both
+  - group: A group of students jointly scheduled for, assigned to, or engaged in educational activities in a context not covered by a class
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - class
   - team

--- a/v6/enumerations/learningComponentType.yaml
+++ b/v6/enumerations/learningComponentType.yaml
@@ -1,16 +1,19 @@
 type: string
 description: |
   The type of learning component, indicating the format or method of educational delivery:
-  - lecture: classroom-based or online lecture given by an instructor
-  - practical: hands-on session focusing on application of concepts
-  - tutorial: interactive session in small groups to reinforce learning
-  - consultation: scheduled meeting for individual or group guidance
-  - project: structured assignment carried out over a period of time
-  - workshop: intensive session focused on practical skills or knowledge
-  - excursion: educational trip or site visit
-  - independent_study: self-directed learning without scheduled contact hours
-  - external: activity taking place outside the institution, such as internships or courses at partner institutions
-  - skills_training: session focused on developing specific practical or professional skills
+
+  - lecture: A classroom-based or online lecture delivered by an instructor
+  - practical: A hands-on session focusing on the application of concepts
+  - tutorial: An interactive session in small groups to reinforce learning
+  - consultation: A scheduled meeting for individual or group guidance
+  - project: A structured assignment carried out over a period of time
+  - workshop: An intensive session focused on developing practical skills or knowledge
+  - excursion: An educational trip or site visit
+  - independent_study: Self-directed learning without scheduled contact hours
+  - external: An activity taking place outside the institution, such as an internship or course at a partner organisation
+  - skills_training: A session focused on developing specific practical or professional skills
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - lecture
   - practical

--- a/v6/enumerations/learningOutcomeLevel.yaml
+++ b/v6/enumerations/learningOutcomeLevel.yaml
@@ -1,10 +1,13 @@
 type: string
 description: |
-  Level of the learning outcome based on SOLO taxonomy (www.johnbiggs.com.au):
-  - 1: Unistructural, the student can identify or carry out simple procedures; understanding is limited to one relevant aspect
-  - 2: Multistructural, the student can handle several relevant aspects but sees them as unrelated; knowledge is additive
-  - 3: Relational, the student integrates several aspects into a coherent whole; shows deeper understanding of relationships
-  - 4: Extended abstract, the student generalizes and transfers learning to new domains; demonstrates theoretical and abstract thinking
+  The level of the learning outcome, based on the SOLO taxonomy (www.johnbiggs.com.au):
+
+  - 1: Unistructural, the student can identify or carry out simple procedures; understanding is limited to a single relevant aspect
+  - 2: Multistructural, the student can address several relevant aspects, but sees them as unrelated; knowledge is additive
+  - 3: Relational, the student integrates several aspects into a coherent whole, demonstrating deeper understanding of relationships
+  - 4: Extended abstract, the student generalises and applies learning to new domains, demonstrating theoretical and abstract thinking
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - '1'
   - '2'

--- a/v6/enumerations/level.yaml
+++ b/v6/enumerations/level.yaml
@@ -1,21 +1,24 @@
 type: string
 description: |
   The level of this course (ECTS year of study if applicable):
-  - pre_vocational: preparatory education prior to vocational training, typically before mbo level
-  - secondary_vocational_education: mbo
-  - secondary_vocational_education_1: mbo 1, corresponds to levelOfQualification 1
-  - secondary_vocational_education_2: mbo 2, corresponds to levelOfQualification 2
-  - secondary_vocational_education_3: mbo 3, corresponds to levelOfQualification 3
-  - secondary_vocational_education_4: mbo 4, corresponds to levelOfQualification 4
-  - associate_degree: associate degree, corresponds to levelOfQualification 5
-  - bachelor: bachelor, corresponds to levelOfQualification 6
-  - master: master, corresponds to levelOfQualification 7
-  - doctoral: doctoral, corresponds to levelOfQualification 8
-  - post_doctoral: advanced academic or professional qualification beyond the doctoral level
-  - undefined: the level is not specified
-  - undivided: integrated program not divided into bachelor and master phases
-  - nt2_1: Dutch as a second language, Program I, intended for vocational training (CEFR level A2, B1)
-  - nt2_2: Dutch as a second language, Program II, intended for higher education or professional work (CEFR level B2)
+
+  - pre_vocational: Pre-vocational education, preparatory stage prior to vocational training, typically before secondary vocational education (Dutch:mbo) level
+  - secondary_vocational_education: Secondary vocational education (Dutch: mbo)
+  - secondary_vocational_education_1: Secondary vocational education level 1, corresponds to levelOfQualification 1 (Dutch:mbo 1)
+  - secondary_vocational_education_2: Secondary vocational education level 2, corresponds to levelOfQualification 2 (Dutch:mbo 2)
+  - secondary_vocational_education_3: Secondary vocational education level 3, corresponds to levelOfQualification 3 (Dutch:mbo 3)
+  - secondary_vocational_education_4: Secondary vocational education level 4, corresponds to levelOfQualification 4 (Dutch:mbo 4)
+  - associate_degree: Associate degree, corresponds to levelOfQualification 5
+  - bachelor: Bachelor degree, corresponds to levelOfQualification 6
+  - master: Master degree, corresponds to levelOfQualification 7
+  - doctoral: Doctoral level, corresponds to levelOfQualification 8
+  - post_doctoral: Post-doctoral level, advanced academic or professional qualification beyond the doctoral level
+  - undefined: The level is not specified
+  - undivided: Integrated programme not divided into bachelor and master phases
+  - nt2_1: Dutch as a second language, Programme I, intended for vocational training (CEFR level A2–B1)
+  - nt2_2: Dutch as a second language, Programme II, intended for higher education or professional purposes (CEFR level B2)
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - pre_vocational
   - secondary_vocational_education  

--- a/v6/enumerations/levelOfQualification.yaml
+++ b/v6/enumerations/levelOfQualification.yaml
@@ -8,19 +8,21 @@ description: |
   - https://database.nlqf.nl/assets/pdf/schema-en-print.pdf
   
   This list is extended with:
-  - eqf_0: informal or non-formal learning below EQF level 1 (e.g. basic literacy or life skills)
+  - eqf_0: Informal or non-formal learning below EQF level 1, e.g. basic literacy or life skills
   - nlqf_4plus: Dutch pre-university education (VWO), considered above EQF level 4 but not formally mapped to EQF level 5
 
-  - eqf_0: informal or pre-qualification learning below EQF level 1
-  - eqf_1: basic general knowledge and skills to carry out simple tasks
-  - eqf_2: basic factual knowledge and practical skills in a field of work or study
-  - eqf_3: knowledge of facts, principles and processes with basic problem-solving
-  - eqf_4: factual and theoretical knowledge in broad contexts within a field of work or study
-  - nlqf_4plus: Dutch VWO (pre-university secondary education), positioned between EQF level 4 and 5
-  - eqf_5: comprehensive, specialized knowledge and practical skills, typically short-cycle higher education (e.g. associate degree)
-  - eqf_6: advanced knowledge and skills for complex problem-solving, typically bachelor level
-  - eqf_7: highly specialized knowledge and critical awareness, typically master level
-  - eqf_8: knowledge at the most advanced frontier of a field, typically doctoral level
+  - eqf_0: Informal or pre-qualification learning, below EQF level 1
+  - eqf_1: Basic general knowledge and skills to carry out simple tasks
+  - eqf_2: Basic factual knowledge and practical skills in a field of work or study
+  - eqf_3: Knowledge of facts, principles and processes, with basic problem-solving skills
+  - eqf_4: Factual and theoretical knowledge in broad contexts within a field of work or study
+  - nlqf_4plus: Dutch VWO (pre-university secondary education), positioned between EQF levels 4 and 5
+  - eqf_5: Comprehensive, specialised knowledge and practical skills, typically short-cycle higher education (e.g. associate degree)
+  - eqf_6: Advanced knowledge and skills for complex problem-solving, typically bachelor level
+  - eqf_7: Highly specialised knowledge and critical awareness, typically master level
+  - eqf_8: Knowledge at the most advanced frontier of a field, typically doctoral level
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - eqf_0
   - eqf_1

--- a/v6/enumerations/membershipRole.yaml
+++ b/v6/enumerations/membershipRole.yaml
@@ -1,13 +1,16 @@
 type: string
 description: |
-  The role of this person in the context of this membership
-  - student: enrolled participant in the offering
-  - lecturer: delivers or leads the teaching content
-  - teaching_assistant: supports the lecturer in teaching activities
-  - coordinator: responsible for organizational or administrative aspects
-  - invigilator: supervises exams or assessments
-  - assessor: evaluates student performance or work
-  - guest: external participant with a non-standard role
+  The role of this person in the context of this membership:
+
+  - student: Enrolled participant in the offering
+  - lecturer: Delivers lectures or leads teaching
+  - teaching_assistant: Supports the lecturer in teaching activities
+  - coordinator: Responsible for organisational or administrative aspects
+  - invigilator: Supervises examinations or assessments
+  - assessor: Evaluates student performance or work
+  - guest: External participant with an atypical role
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - student
   - lecturer

--- a/v6/enumerations/membershipState.yaml
+++ b/v6/enumerations/membershipState.yaml
@@ -1,9 +1,12 @@
 type: string
 description: |
   The state of this membership:
-  - canceled: the membership has been formally terminated and is no longer valid
-  - active: the membership is currently valid and in effect
+
+  - cancelled: The membership has been formally terminated and is no longer valid
+  - active: The membership is currently valid and in effect
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
-  - canceled
+  - cancelled
   - active
 example: active

--- a/v6/enumerations/modeOfDelivery.yaml
+++ b/v6/enumerations/modeOfDelivery.yaml
@@ -1,13 +1,17 @@
 type: string
 description: |
-  The mode of delivery of the component based on https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/learning-assessment
-  - presential: classroom learning
-  - online: real-time online learning
-  - hybrid: use different modes of delivery in a flexible way
-  - blended: mix online and offline learning
-  - research_lab_based: learning while doing research
-  - work_based: learning on the job
-  - project_based: learning/testing within a project team
+  The mode of delivery of the component, based on the EU vocabulary:  
+  https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/learning-assessment
+
+  - presential: Learning that takes place in a physical classroom setting
+  - online: Real-time learning delivered entirely via the internet
+  - hybrid: Delivery using different modes in a flexible and interchangeable way
+  - blended: Structured combination of online and in-person learning
+  - research_lab_based: Learning that occurs within a research environment
+  - work_based: Learning through practical work or workplace experience
+  - project_based: Learning or assessment conducted as part of a project team
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - presential
   - online

--- a/v6/enumerations/modeOfStudy.yaml
+++ b/v6/enumerations/modeOfStudy.yaml
@@ -1,10 +1,13 @@
 type: string
 description: |
-  Indicates whether the education is full-time, part-time, dual or self-paced.
-    - full_time: regular day-time study
-    - part_time: study outside business hours, during evening en week-ends.
-    - dual_training: combine learning on the job and study
-    - self_paced: student determines study tempo
+  Indicates the mode of study: full-time, part-time, dual or self-paced.
+
+  - full_time: Standard daytime study schedule
+  - part_time: Study scheduled outside regular working hours, such as evenings and weekends
+  - dual_training: Combination of workplace learning and academic study
+  - self_paced: Student sets their own pace and timing for study
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - full_time
   - part_time

--- a/v6/enumerations/offeringState.yaml
+++ b/v6/enumerations/offeringState.yaml
@@ -1,13 +1,16 @@
 type: string
 description: |
-  The state of this offering
+  The state of this offering:
+
   - concept: The offering is still in development and not yet available for students
-  - canceled: The offering has been canceled and is no longer available
-  - active: The offering is currently available for students to enroll in and participate
+  - cancelled: The offering has been cancelled and is no longer available
+  - active: The offering is currently available for students to enrol in and participate
   - inactive: The offering is not currently available for students, but may be available in the future
+
+  This is an extensible enumeration. Use the prefix x- for custom values.
 x-ooapi-extensible-enum:
   - concept
-  - canceled
+  - cancelled
   - active
   - inactive
 example: active

--- a/v6/enumerations/offeringType.yaml
+++ b/v6/enumerations/offeringType.yaml
@@ -1,12 +1,15 @@
 type: string
 description: |
   The type of offering based on the object that is offered:
-  - program: a complete programme of study leading to a qualification or degree
-  - course: a structured unit of learning within a programme, often carrying credit
-  - learning_component: a part of a course or programme focused on specific content or activity (e.g. lecture, project)
-  - test_component: an assessment element used to evaluate knowledge, skills, or competence (e.g. exam, presentation)
+
+  - programme: A complete programme of study leading to a qualification or degree
+  - course: A structured unit of learning within a programme, often carrying credit
+  - learning_component: A part of a course or programme focused on specific content or activity (e.g. lecture, project)
+  - test_component: An assessment element used to evaluate knowledge, skills, or competence (e.g. exam, presentation)
+
+  This is an extensible enumeration. Use the prefix x- for custom values.
 x-ooapi-extensible-enum:
-  - program
+  - programme
   - course
   - learning_component
   - test_component

--- a/v6/enumerations/organizationType.yaml
+++ b/v6/enumerations/organizationType.yaml
@@ -1,13 +1,16 @@
 type: string
 description: |
-  The type of this organization. Each OOAPI endpoint should have a single organization with type `root`, describing the root organization.
-  - root: the top-level organization, representing the educational institution itself
-  - institute: a subdivision of the root organization, typically focused on a broad field of study
-  - department: an organizational unit within a faculty or institute, focused on a specific discipline
-  - faculty: a major academic division within the institution, often overseeing multiple departments
-  - branch: a geographically separate location or campus of the institution
-  - academy: a specialized academic unit, often focused on applied or artistic disciplines
-  - school: an organizational unit typically used in primary, secondary, or specialized higher education contexts
+  The type of this organisation. Each OOAPI endpoint should have a single organisation with type root, describing the root organisation.
+
+  - root: The top-level organisation, representing the educational institution itself
+  - institute: A subdivision of the root organisation, typically focused on a broad field of study
+  - department: An organisational unit within a faculty or institute, focused on a specific discipline
+  - faculty: A major academic division within the institution, often overseeing multiple departments
+  - branch: A geographically separate location or campus of the institution
+  - academy: A specialised academic unit, often focused on applied or artistic disciplines
+  - school: An organisational unit typically used in primary, secondary, or specialised higher education contexts
+
+  This is an extensible enumeration. Use the prefix x- for custom values.
 x-ooapi-extensible-enum:
   - root
   - institute

--- a/v6/enumerations/passState.yaml
+++ b/v6/enumerations/passState.yaml
@@ -1,9 +1,12 @@
 type: string
 description: |
   The state of this result:
-  - unknown: the result has not been determined, recorded, or is not yet available
-  - passed: the individual has met the required criteria to pass
-  - failed: the individual did not meet the required criteria to pass
+
+  - unknown: The result has not been determined, recorded, or is not yet available
+  - passed: The individual has met the required criteria to pass
+  - failed: The individual did not meet the required criteria to pass
+
+  This is an extensible enumeration. Use the prefix x- for custom values.
 x-ooapi-extensible-enum:
   - unknown
   - passed

--- a/v6/enumerations/personAffiliation.yaml
+++ b/v6/enumerations/personAffiliation.yaml
@@ -1,9 +1,12 @@
 type: string
 description: |
-  The affiliations of this person — the roles or relationships a person has with the organization providing this endpoint:
-  - student: enrolled learner or participant in educational offerings
-  - employee: staff member employed by the organization (e.g. teacher, administrator)
-  - guest: external person temporarily affiliated, without formal student or employee status
+  The affiliations of this person — the roles or relationships a person has with the organisation providing this endpoint:
+
+  - student: Enrolled learner or participant in educational offerings
+  - employee: Staff member employed by the organisation (e.g. teacher, administrator)
+  - guest: External person temporarily affiliated, without formal student or employee status
+
+  This is an extensible enumeration. Use the prefix x- for custom values.
 x-ooapi-extensible-enum:
   - student
   - employee

--- a/v6/enumerations/personalNeed.yaml
+++ b/v6/enumerations/personalNeed.yaml
@@ -1,11 +1,16 @@
 type: string
 description: |
-  The personal needs that are required for this component for this specific candidate. 
-  This is a list of the personal needs that are required for this component for this specific candidate.
-  The enum list is a selection from the imsglobal personal needs. For the full list, see https://www.imsglobal.org/sites/default/files/spec/afa/3p0/information_model/imsafa3p0pnp_v1p0_InfoModel.html
-  - extra_time: additional time allocated for completing the component beyond standard timing
-  - spoken: spoken output support (e.g. text-to-speech)
-  - spell_checker_on_screen: on-screen spell checking tool enabled during writing tasks
+  The personal needs required for this component by this specific candidate.
+
+  This list is a selection from the IMS Global Personal Needs and Preferences specification.
+  For the full reference, see:  
+  https://www.imsglobal.org/sites/default/files/spec/afa/3p0/information_model/imsafa3p0pnp_v1p0_InfoModel.html
+
+  - extra_time: Additional time allocated for completing the component beyond standard timing
+  - spoken: Spoken output support (e.g. text-to-speech)
+  - spell_checker_on_screen: On-screen spell checking tool enabled during writing tasks
+
+  This is an extensible enumeration. Use the prefix x- for custom values.
 x-ooapi-extensible-enum:
   - extra_time
   - spoken

--- a/v6/enumerations/programType.yaml
+++ b/v6/enumerations/programType.yaml
@@ -1,17 +1,21 @@
 type: string
 description: |
-  The type of this program:
-  - program: a full formal programme of study leading to a qualification or degree
-  - minor: a smaller, complementary program that broadens or deepens the main field of study
-  - honours: an honours program, typically with additional academic requirements or distinction
-  - specialization: a focused area of study within a broader program or degree
-  - track: a structured learning path within a program, often thematically or methodologically defined
-  - specification: a further defined variant or subset of a track or specialization
+  The type of this programme:
+
+  - programme: A full formal programme of study leading to a qualification or degree
+  - minor: A smaller, complementary programme that broadens or deepens the main field of study
+  - honours: An honours programme, typically with additional academic requirements or distinction
+  - specialisation: A focused area of study within a broader programme or degree
+  - track: A structured learning path within a programme, often thematically or methodologically defined
+  - specification: A further defined variant or subset of a track or specialisation
+
+  This is an extensible enumeration. Use the prefix x- for custom values.
 x-ooapi-extensible-enum:
-  - program
+  - programme
   - minor
   - honours
-  - specialization
+  - specialisation
   - track
   - specification
-example: program
+example: 
+  - programme

--- a/v6/enumerations/qualificationAwarded.yaml
+++ b/v6/enumerations/qualificationAwarded.yaml
@@ -1,15 +1,17 @@
 type: string
 description: |
-  Type of qualification that can be obtained upon completing the program:
-  - ad: Associate degree — short-cycle higher education qualification (EQF level 5)
-  - ba: Bachelor of Arts — undergraduate degree typically in the humanities or social sciences (EQF level 6)
-  - bsc: Bachelor of Science — undergraduate degree typically in the sciences, technology, or economics (EQF level 6)
-  - llb: Bachelor of Laws — undergraduate law degree (EQF level 6)
-  - ma: Master of Arts — postgraduate degree in the humanities or social sciences (EQF level 7)
-  - msc: Master of Science — postgraduate degree in science, technology, or economics (EQF level 7)
-  - llm: Master of Laws — postgraduate law degree (EQF level 7)
-  - phd: Doctor of Philosophy — research-based doctoral degree (EQF level 8)
-  - none: no formal qualification is awarded for this program
+  Type of qualification that can be obtained upon completing the programme:
+    
+  - ad: Associate degree, short-cycle higher education qualification (EQF level 5)
+  - ba: Bachelor of Arts, undergraduate degree typically in the Humanities or Social Sciences (EQF level 6)
+  - bsc: Bachelor of Science, undergraduate degree typically in the Sciences, Technology, or Economics (EQF level 6)
+  - llb: Bachelor of Laws, undergraduate Law degree (EQF level 6)
+  - ma: Master of Arts, postgraduate degree in the Humanities or Social Sciences (EQF level 7)
+  - msc: Master of Science, postgraduate degree in Science, Technology, or Economics (EQF level 7)
+  - llm: Master of Laws, postgraduate Law degree (EQF level 7)
+  - phd: Doctor of Philosophy, research-based Doctoral degree (EQF level 8)
+  - none: No formal qualification is awarded for this programme
+
 x-ooapi-extensible-enum:
   - ad
   - ba

--- a/v6/enumerations/remoteAssociationState.yaml
+++ b/v6/enumerations/remoteAssociationState.yaml
@@ -1,14 +1,17 @@
 type: string
 description: |
-  The state of this association for the institution performing the request:
-  - pending: the association request has been submitted but not yet processed
-  - canceled: the association request was withdrawn before being completed
-  - denied: the association request was reviewed and explicitly rejected
-  - associated: the association has been successfully established and is active
-  - queued: the association request is awaiting processing in a queue
+  The state of this association for the organisation performing the request:
+
+  - pending: The association request has been submitted, but not yet processed
+  - cancelled: The association request was withdrawn before being completed
+  - denied: The association request was reviewed, and explicitly rejected
+  - associated: The association has been successfully established, and is active
+  - queued: The association request is awaiting processing in a queue
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - pending
-  - canceled
+  - cancelled
   - denied
   - associated
   - queued

--- a/v6/enumerations/resultState.yaml
+++ b/v6/enumerations/resultState.yaml
@@ -1,10 +1,13 @@
 type: string
 description: |
   The state of this result:
-  - in_progress: the result is currently being worked on or assessed
-  - postponed: the result process has been delayed and will be resumed later
-  - completed: the result has been finalized and recorded
-  - queued: the result is awaiting processing or evaluation
+
+  - in_progress: The result is currently being worked on or assessed
+  - postponed: The result process has been delayed and will be resumed later
+  - completed: The result has been finalised and recorded
+  - queued: The result is awaiting processing or evaluation
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - in_progress
   - postponed

--- a/v6/enumerations/resultValueType.yaml
+++ b/v6/enumerations/resultValueType.yaml
@@ -1,16 +1,19 @@
 type: string
 description: |
-  The result value type for this offering
-  - pass_or_fail: A simple pass or fail result
-  - insufficient_satisfactory_good: A result with three levels: insufficient, satisfactory, and good
-  - us_letter: A result in the US letter grading system (A, B, C, D, F)
-  - uk_letter: A result in the UK letter grading system (A, B, C, D, E, U)
-  - de_grade: A result in the German grading system (1, 2, 3, 4, 5, 6)
-  - grade_0_100: A result in the 0-100 grading system
-  - grade_0_10: A result in the 0-10 grading system. No decimals allowed.
-  - grade_0_10_one_decimal: A result in the 0-10 grading system with one decimal place
-  - reference_level_europass: A result in the Europass reference level grading system (A1, A2, B1, B2, C1, C2)
-  - other: Any other grading system not specified above
+  The result value type for this offering.
+
+  - pass_or_fail: A simple pass or fail result.
+  - insufficient_satisfactory_good: A result with three levels (insufficient, satisfactory and good).
+  - us_letter: A result in the US letter grading system (A, B, C, D, F).
+  - uk_letter: A result in the UK letter grading system (A, B, C, D, E, U).
+  - de_grade: A result in the German grading system (1, 2, 3, 4, 5, 6).
+  - grade_0_100: A result in the 0–100 grading system.
+  - grade_0_10: A result in the 0–10 grading system (no decimals allowed).
+  - grade_0_10_one_decimal: A result in the 0–10 grading system (with one decimal place).
+  - reference_level_europass: A result in the Europass reference level grading system (A1, A2, B1, B2, C1, C2).
+  - other: Any other grading system not specified above.
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - pass_or_fail
   - insufficient_satisfactory_good

--- a/v6/enumerations/roomType.yaml
+++ b/v6/enumerations/roomType.yaml
@@ -1,16 +1,19 @@
 type: string
 description: |
-  The type of this room:
-  - general_purpose: multi-purpose space used for general activities or flexible functions
-  - lecture_room: room primarily used for lectures or large instructional sessions
-  - computer_room: space equipped with computers for teaching, training, or research
-  - laboratory: room designed for practical experiments, testing, or scientific work
-  - office: workspace for administrative or academic staff
-  - workspace: shared or individual area for working or studying
-  - exam_location: designated space for taking written or digital exams
-  - study_room: quiet area intended for individual or group study
-  - examination_room: private space for medical or psychological assessments
-  - conference_room: room intended for meetings, discussions, or presentations
+  The type of this room.
+
+  - general_purpose: Multi-purpose space used for general activities or flexible functions.
+  - lecture_room: Room primarily used for lectures or large instructional sessions.
+  - computer_room: Space equipped with computers for teaching, training or research.
+  - laboratory: Room designed for practical experiments, testing or scientific work.
+  - office: Workspace for administrative or academic staff.
+  - workspace: Shared or individual area for working or studying.
+  - exam_location: Designated space for taking written or digital examinations.
+  - study_room: Quiet area intended for individual or group study.
+  - examination_room: Private space for medical or psychological assessments.
+  - conference_room: Room intended for meetings, discussions or presentations.
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - general_purpose
   - lecture_room

--- a/v6/enumerations/studyloadUnit.yaml
+++ b/v6/enumerations/studyloadUnit.yaml
@@ -1,11 +1,14 @@
 type: string
 description: |
   The unit in which the study load is specified:
-  - contacttime: amount of time spent in scheduled classroom or contact hours
-  - ects: European Credit Transfer and Accumulation System (ECTS credits), typically 1 ECTS = 28 study hours
-  - sbu: student workload hours, representing the total estimated effort
-  - sp: study points used in some national systems (e.g. studiepunt in Flanders or the Netherlands)
-  - hour: plain number of hours, regardless of context (e.g. used for informal or modular learning units)
+
+  - contacttime: Amount of time spent in scheduled classroom or contact hours.
+  - ects: European Credit Transfer and Accumulation System (ECTS credits), typically 1 ECTS = 28 study hours.
+  - sbu: Student workload hours, representing the total estimated effort.
+  - sp: Study points used in some national systems (e.g. studiepunt in Flanders or the Netherlands).
+  - hour: Plain number of hours, regardless of context (e.g. used for informal or modular learning units).
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - contacttime
   - ects

--- a/v6/enumerations/testComponentType.yaml
+++ b/v6/enumerations/testComponentType.yaml
@@ -1,12 +1,15 @@
 type: string
 description: |
-  The way the test is conducted. This can be a test on paper, a digital test, a life skills test, an oral test, or a portfolio assessment.
-  Together with modeOfStudy/Assessment it indicates where the test is taken and how it is conducted:
-  - test_on_paper: written examination on paper, typically in a controlled setting
-  - digital_test: computer-based or online test, conducted via a digital platform
-  - life_skills_test: practical assessment of real-world competencies and life skills
-  - oral_test: spoken examination, typically involving verbal questioning and answering
-  - portfolio_assessment: evaluation based on a collection of the candidate’s work over time
+  The way the test is conducted. This can be a test on paper, a digital test, a life skills test, an oral test, or a portfolio assessment.  
+  Together with modeOfStudy or assessment, it indicates where the test is taken and how it is conducted:
+
+  - test_on_paper: Written examination on paper, typically in a controlled setting.
+  - digital_test: Computer-based or online test, conducted via a digital platform.
+  - life_skills_test: Practical assessment of real-world competencies and life skills.
+  - oral_test: Spoken examination, typically involving verbal questioning and answering.
+  - portfolio_assessment: Evaluation based on a collection of the candidate's work over time.
+
+  This is an *extensible enumeration*. Use the prefix `x-` for custom values.
 x-ooapi-extensible-enum:
   - test_on_paper
   - digital_test


### PR DESCRIPTION
The enumerations below have been adjusted. Furthermore, the descriptions use British terms wherever possible instead of American ones.

billing -> invoicing
specialization -> specialisation
canceled -> cancelled
program -> programme
organization_id -> organisation_id

Rest is under discussion, merge now is so we have no conflicts later on.