### PR TITLE
Attempt on test component offering association

### DIFF
--- a/v6/schemas/Document.yaml
+++ b/v6/schemas/Document.yaml
@@ -1,0 +1,16 @@
+type: object
+required:
+  - documentId
+  - documentType
+  - documentName
+properties:
+  documentId:
+    type: string
+    description: The unique identifier of the document
+    example: 12345678-1234-1234-1234-123456789012
+  documentType:
+    $ref: ../enumerations/documentType.yaml
+  documentName:
+    type: string
+    description: The name of the document
+    example: paper_test_1234333.pdf

--- a/v6/schemas/OfferingProperties.yaml
+++ b/v6/schemas/OfferingProperties.yaml
@@ -32,6 +32,9 @@ properties:
     example:
     - language: en-GB
       value: Final written test for INFOMQNM for fall semseter 2020
+  state:
+    $ref: '../enumerations/offeringState.yaml'
+    description: The state of this offering, e.g. active, inactive, archived
   abbreviation:
     type: string
     description: The abbreviation or internal code used to identify this offering

--- a/v6/schemas/Result.yaml
+++ b/v6/schemas/Result.yaml
@@ -6,7 +6,6 @@ required:
 properties:
   state:
     $ref: '../enumerations/resultState.yaml'
-# added state based on request by CACI
   pass:
     $ref: '../enumerations/passState.yaml'
   comment:
@@ -16,10 +15,48 @@ properties:
     type: string
     description: The score of this program/course/component association (based on resultValueType in offering)
     example: '9'
+  rawScore:
+    type: integer
+    description: |
+      The number of points scored by a person (on the test or assessment form) which the result could be calculated. 
+      The raw score provides additional insight in the achievement of the person. 
+      The raw score also needs the value of maxRawScore to provide necessary context.
+  maxRawScore:
+    type: integer
+    description: |
+      The maximum number of points a person could achieve on the test or assessment form.
+  final:
+    type: boolean
+    default: false
+    description: |
+      final: indicates that the result has been finalised by the exam committee. 
+      Can be done in any step of the test taking and assessment cycle. 
+    example: true  
+  assessor:
+    description: |
+      The assessor responsible for evaluating the result.
+    oneOf:
+      - $ref: './Identifier.yaml'
+        title: assessorId
+      - $ref: './Person.yaml'
+        title: Person object
   resultDateTime:
     type: string
     description: The date this result has been published, RFC3339 (full-date)
     format: date-time
     example: '2025-11-28T08:30:00+01:00'
+  documents:
+    type: array
+    description: |
+      Documents that are related to the result of the test component offering association. E.g. assessment form, assessment model, etc.
+    items:
+      $ref: './Document.yaml'
+  consumers:
+    description: The additional consumer elements that can be provided, see the [documentation on support for specific consumers](https://openonderwijsapi.nl/#/technical/consumers-and-profiles/) for more information about this mechanism.
+    type: array
+    items:
+      $ref: './Consumer.yaml'
+    example:
+      $ref: '../consumers/TEST/V1/examples/TestConsumer.yaml'
   ext:
     $ref: './Ext.yaml'

--- a/v6/schemas/TestComponentOfferingAssociation.yaml
+++ b/v6/schemas/TestComponentOfferingAssociation.yaml
@@ -29,21 +29,6 @@ allOf:
         description: |
           Documents that are related to the test component offering association. E.g. handed in documents, plagiarism reports, test made, etc.
         items:
-          type: object
-          required:
-            - documentId
-            - documentType
-            - documentName
-          properties:
-            documentId:
-              type: string
-              description: The unique identifier of the document
-              example: 12345678-1234-1234-1234-123456789012
-            documentType:
-              $ref: ../enumerations/documentType.yaml
-            documentName:
-              type: string
-              description: The name of the document
-              example: paper_test_1234333.pdf
+          $ref: './Document.yaml'
       result:
         $ref: './TestComponentOfferingAssociationResult.yaml'

--- a/v6/schemas/TestComponentOfferingAssociationAttempt.yaml
+++ b/v6/schemas/TestComponentOfferingAssociationAttempt.yaml
@@ -1,0 +1,86 @@
+type: object
+description: |
+  Planning and execution information on an attempt belong to a TestComponentOfferingAssociation. Result on the attempt
+  is only relevant when a score or rawScore could be determined.
+required:
+  - attemptId
+properties:
+  attemptId:
+    type: string
+    description: Unique id of this attempt
+    format: uuid
+    example: 123e4567-e89b-12d3-a456-426614174000
+  opportunity:
+    type: string
+    description: |
+      The opportunity during which this attempt can be fulfilled. 
+      Only relevant when only one attempt is allowed per association.
+      example: "2025Semester1"
+  attempt:
+    type: integer
+    description: |
+      Which attempt this is for the given person on the given offering
+    format: int32
+  planningState:
+    type: string
+    description: |
+      Status of the fulfilment of the attempt. The status typically progresses from pending to associated and then to finished (possibly canceled with canceled). Based on enum
+    enum:
+      - associated
+      - canceled
+      - pending
+      - finished 
+    example: associated
+  startDateTime:
+    type: string
+    description: Moment (date and time) of the start of the actual test.
+    format: date-time
+  endDateTime:
+    type: string
+    description: Moment (date and time) of the end of the actual test.
+    format: date-time
+  room:
+    $ref: './Room.yaml'
+  attendance:
+    type: string
+    description: |
+      Indication of the attendance of a student during the test.
+      Possible values are:
+      not_known (No information on presence available or not yet known)
+      not_present (not present),
+      not_started (present but not started),
+      not_finished (present and started but not finished/submitted)
+      and present (present and finished/submitted)"
+    enum:
+      - not_known
+      - not_present
+      - not_started
+      - not_finished
+      - present
+  irregularities:
+    type: string
+    description: Additional information about the situation during ht etest, e.g. the irregularities or specifics during which the test took place.
+    example: The student was late because there was a train delay
+  coordinator:
+    description: |
+      The coordinator responsible for overseeing the test
+    oneOf:
+      - $ref: './Identifier.yaml'
+        title: coordinatorId
+      - $ref: './Person.yaml'
+        title: Person object
+  documents:
+    type: array
+    description: |
+      Documents that are related to the test component offering association attempt. E.g. test made, work handed in, etc.
+    items:
+      $ref: './Document.yaml'
+  result:
+    $ref: './Result.yaml'
+  consumers:
+    description: The additional consumer elements that can be provided, see the [documentation on support for specific consumers](https://openonderwijsapi.nl/#/technical/consumers-and-profiles/) for more information about this mechanism.
+    type: array
+    items:
+      $ref: './Consumer.yaml'
+    example:
+      $ref: '../consumers/TEST/V1/examples/TestConsumer.yaml'

--- a/v6/schemas/TestComponentOfferingAssociationAttemptFull.yaml
+++ b/v6/schemas/TestComponentOfferingAssociationAttemptFull.yaml
@@ -1,0 +1,14 @@
+allOf:
+  - $ref: './TestComponentOfferingAssociationAttempt.yaml'
+  - type: object
+    properties:
+      courseOfferingAssociationId: 
+        type: string
+        description: |
+          The unique identifier of the enrollment of the student in a courseOffering on the behalf of the current assocation is taking place 
+        format: uuid
+      testComponentOfferingAssociationId:
+        type: string
+        description: |
+          The associationId under which this attempt was made.
+        format: uuid

--- a/v6/schemas/TestComponentOfferingAssociationExpandable.yaml
+++ b/v6/schemas/TestComponentOfferingAssociationExpandable.yaml
@@ -1,9 +1,12 @@
 allOf:
-  - $ref: './AssociationId.yaml'
-  - $ref: './AssociationProperties.yaml'
+  - $ref: './TestComponentOfferingAssociation.yaml'
   - type: object
     properties:
-      result:
-        $ref: './TestComponentOfferingAssociationResult.yaml'
       person:
         $ref: './PersonId.yaml'
+      testComponentOffering:
+        $ref: './OfferingId.yaml'
+      attempts:
+        type: array
+        items:
+          $ref: './Identifier.yaml'

--- a/v6/schemas/TestComponentOfferingAssociationExpanded.yaml
+++ b/v6/schemas/TestComponentOfferingAssociationExpanded.yaml
@@ -8,9 +8,17 @@ properties:
         title: personId
       - $ref: './Person.yaml'
         title: Person
-  offering:
+  testComponentOffering:
     oneOf:
       - $ref: './Identifier.yaml'
         title: offeringId
       - $ref: './TestComponentOffering.yaml'
         title: TestComponentOffering
+  attempts:
+    type: array
+    items:
+      oneOf: 
+        - $ref: './Identifier.yaml'
+          title: attemptId
+        - $ref: './TestComponentOfferingAssociationAttempt.yaml'
+          title: TestComponentOfferingAssociationAttempt


### PR DESCRIPTION
Pull request on issue #375 . PR seems better for collecting targeted feedback than exchanging more examples:

Based on feedback from @hamrt @jonasdegraaff and @jelmerderonde I made the following changes:

- No changes in paths yet. Want to get review comments first on the model changes
- Attempt is now a separate entity within an testComponentOfferingAssociation
- Result is still an object within associations and also within attempt. IMHO it became too complex to have results have their own id's too. Now a result is available within the context of an association or attempt. 
    - result on an attempt is the result achieved during that attempt.
    - result on an association is the result that can depend upon business logic how to make use of results on attempts (latest, highest, average etc) or a totally separate result determined by an exam committee eg. exemption/vrijstelling or fraudulent behaviour.
 - introduced attempt properties and ..full definitions to use stand alone and as expand on an association.

TO DO:
Proposed paths:

GET .../testComponentOfferingAssociations/{associationId}?expand=attempts to get an association with al its attempts expanded
GET .../testComponentOfferingAssociationAttempt/{attemptId}

PUT ..../testComponentOfferingAssociation/{associationId}/attempt/{attemptId} to facilitate easy processing by SIS when it receives back attempt information back on an association it provided to another (test planning) system.

Detailed evaluation of generic OKE attributes into the OOAPIv6 standard