### PR TITLE
423 bad use of   and ref in definitions in items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.0.0 Change required fields - 2025-08-20
+## [6.0.0 Change required fields] - 2025-08-25
+
+### Added
+
+### Removed
+
+### Changed
+- Resolved: replaced all invalid 'items: - $ref' occurrences with the correct 'items: $ref', ensuring valid OpenAPI syntax and proper display in Redoc.
+
+## [6.0.0 Change required fields] - 2025-08-20
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.0.0 Change required fields] - 2025-08-25
+## [6.0.0 Change 'items: - $ref' error] - 2025-08-25
 
 ### Added
 

--- a/v6/paths/CourseOfferingCourseOfferingAssociationCollection.yaml
+++ b/v6/paths/CourseOfferingCourseOfferingAssociationCollection.yaml
@@ -48,7 +48,7 @@ get:
                   items:
                     type: array
                     items:
-                        - $ref: '../schemas/CourseOfferingAssociationExpandable.yaml'
+                        $ref: '../schemas/CourseOfferingAssociationExpandable.yaml'
                   ext:
                     $ref: '../schemas/Ext.yaml'
     '400':

--- a/v6/paths/LearningComponentOfferingLearningComponentOfferingAssociationCollection.yaml
+++ b/v6/paths/LearningComponentOfferingLearningComponentOfferingAssociationCollection.yaml
@@ -48,7 +48,7 @@ get:
                   items:
                     type: array
                     items:
-                      - $ref: '../schemas/LearningComponentOfferingAssociationExpandable.yaml'
+                      $ref: '../schemas/LearningComponentOfferingAssociationExpandable.yaml'
                   ext:
                     $ref: '../schemas/Ext.yaml'
     '400':

--- a/v6/paths/TestComponentOfferingTestComponentOfferingAssociationCollection.yaml
+++ b/v6/paths/TestComponentOfferingTestComponentOfferingAssociationCollection.yaml
@@ -48,7 +48,7 @@ get:
                   items:
                     type: array
                     items:
-                        - $ref: '../schemas/TestComponentOfferingAssociationExpandable.yaml'
+                        $ref: '../schemas/TestComponentOfferingAssociationExpandable.yaml'
                   ext:
                     $ref: '../schemas/Ext.yaml'
     '400':


### PR DESCRIPTION
Resolved: replaced all invalid items: - $ref occurrences with the correct items: $ref form, ensuring valid OpenAPI syntax and proper display in Redoc.