### PR TITLE
414 security in ooapi how to handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0 Change move security to documentation] - 2025-08-26
+
+### Added
+
+### Removed
+
+### Changed
+- Resolved: all security-related aspects moved to documentation, ensuring the specification remains clean and free from implementation details
+
 ## [6.0.0 Change 'items: - $ref' error] - 2025-08-25
 
 ### Added

--- a/v6/paths/CourseOfferingAssociationInstance.yaml
+++ b/v6/paths/CourseOfferingAssociationInstance.yaml
@@ -58,9 +58,14 @@ patch:
     Implementation of the PATCH activity is based on use PATCH with JSON Merge Patch standard, 
     a specialized media type `application/merge-patch+json` for partial resource representation 
     to update parts of resource objects.
-  security:
-    - openId:
-      - associations.write
+
+    Security must be implemented at the level of the actual deployment rather than in the core 
+    specification. This means that the specification remains neutral, while concrete security 
+    measures can be applied in practice using established techniques such as OpenID with fine-grained 
+    scopes. For example, write access on associations (associations.write) can be granted in this way. 
+    The previous inline declaration has therefore been removed to avoid conflating implementation 
+    details with the specification.
+    
   tags:
     - course offering associations
 

--- a/v6/paths/CourseOfferingAssociationInstanceExternalMe.yaml
+++ b/v6/paths/CourseOfferingAssociationInstanceExternalMe.yaml
@@ -5,9 +5,14 @@ post:
     POST a single course offering association, enroll a person based on person information obtained from .wellknown endpoint, an offering, 
     and the organization/type=root information form the organization that is issuing this association. 
     The offering can either be identified by an offeringId if known or the full offering details. 
-  security:
-    - openId:
-      - course-offering-associations:external:me.write
+
+    Security must be implemented at the level of the actual deployment rather than in the core specification. 
+    This means that the specification remains neutral, while concrete security measures can be applied in 
+    practice using established techniques such as OpenID with fine-grained scopes. For example, write access 
+    on course-offering associations for an external user (me.write) can be granted in this way. The previous 
+    inline declaration has therefore been removed to avoid conflating implementation details with the 
+    specification.
+
   tags:
     - course offering associations
 

--- a/v6/paths/DocumentInstance.yaml
+++ b/v6/paths/DocumentInstance.yaml
@@ -1,10 +1,15 @@
 get:
   summary: GET /documents/{documentId}
   operationId: listDocumentById
-  description: Get the binary data from a document.
-  security:
-    - oAuthFlows:
-      - nl-test-admin-flow-2-3-4
+  description: |
+    Get the binary data from a document.
+
+    Security must be implemented at the level of the actual deployment rather than in the core specification. 
+    This means that the specification remains neutral, while concrete security measures can be applied in practice 
+    using established techniques such as OAuth flows with fine-grained definitions. For example, access may be 
+    managed through the flow identified as nl-test-admin-flow-2-3-4. The previous inline declaration has therefore 
+    been removed to avoid conflating implementation details with the specification.
+
   tags:
     - documents
   parameters:

--- a/v6/paths/LearningComponentOfferingAssociationInstance.yaml
+++ b/v6/paths/LearningComponentOfferingAssociationInstance.yaml
@@ -58,9 +58,13 @@ patch:
     Implementation of the PATCH activity is based on use PATCH with JSON Merge Patch standard, 
     a specialized media type `application/merge-patch+json` for partial resource representation 
     to update parts of resource objects.
-  security:
-    - openId:
-      - associations.write
+
+    Security must be implemented at the level of the actual deployment rather than in the core 
+    specification. This means that the specification remains neutral, while concrete security 
+    measures can be applied in practice using established techniques such as OpenID with fine-grained 
+    scopes (for example, write access on associations). The previous inline declaration has therefore
+    been removed to avoid conflating implementation details with the specification.
+    
   tags:
     - learning component offering associations
 

--- a/v6/paths/PersonMe.yaml
+++ b/v6/paths/PersonMe.yaml
@@ -1,9 +1,13 @@
 get:
   summary: GET /persons/me
   operationId: listPersonByMyOauthId
-  description: Returns the person object for the currently authenticated user.
-  security:
-    - openId: []
+  description: |
+    Returns the person object for the currently authenticated user.
+
+    Security must be implemented at the level of the actual deployment rather than in the core 
+    specification. This means that the specification remains neutral, while concrete security 
+    measures can be applied in practice using established techniques such as OpenID with 
+    fine-grained scopes.
   tags:
     - persons
   responses:

--- a/v6/paths/ProgramOfferingAssociationInstance.yaml
+++ b/v6/paths/ProgramOfferingAssociationInstance.yaml
@@ -58,9 +58,13 @@ patch:
     Implementation of the PATCH activity is based on use PATCH with JSON Merge Patch standard, 
     a specialized media type `application/merge-patch+json` for partial resource representation 
     to update parts of resource objects.
-  security:
-    - openId:
-      - associations.write
+
+    Security must be implemented at the level of the actual deployment rather than in the core 
+    specification. This means that the specification remains neutral, while concrete security 
+    measures can be applied in practice using established techniques such as OpenID with fine-grained 
+    scopes (for example, write access on associations). The previous inline declaration has therefore
+    been removed to avoid conflating implementation details with the specification.
+
   tags:
     - program offering associations
 

--- a/v6/paths/ProgramOfferingAssociationInstanceExternalMe.yaml
+++ b/v6/paths/ProgramOfferingAssociationInstanceExternalMe.yaml
@@ -5,9 +5,13 @@ post:
     POST a single program offering association, enroll a person based on person information obtained from .wellknown endpoint, an offering, 
     and the organization/type=root information form the organization that is issuing this association. 
     The offering can either be identified by an offeringId if known or the full offering details. 
-  security:
-    - openId:
-      - program-offering-associations:external:me.write
+
+    Security must be implemented at the level of the actual deployment rather than in the core specification. 
+    This means that the specification remains neutral, while concrete security measures can be applied in 
+    practice using established techniques such as OpenID with fine-grained scopes. For example, write access 
+    on programme-offering associations for an external user (“me.write”) can be granted in this way. The previous 
+    inline declaration has therefore been removed to avoid conflating implementation details with the specification.
+
   tags:
     - program offering associations
 

--- a/v6/paths/TestComponentOfferingAssociationInstance.yaml
+++ b/v6/paths/TestComponentOfferingAssociationInstance.yaml
@@ -57,9 +57,13 @@ patch:
     Implementation of the PATCH activity is based on use PATCH with JSON Merge Patch standard, 
     a specialized media type `application/merge-patch+json` for partial resource representation 
     to update parts of resource objects.
-  security:
-    - openId:
-      - associations.write
+
+    Security must be implemented at the level of the actual deployment rather than in the core 
+    specification. This means that the specification remains neutral, while concrete security 
+    measures can be applied in practice using established techniques such as OpenID with fine-grained 
+    scopes (for example, write access on associations). The previous inline declaration has therefore
+    been removed to avoid conflating implementation details with the specification.
+
   tags:
     - test component offering associations
 

--- a/v6/spec.yaml
+++ b/v6/spec.yaml
@@ -180,14 +180,6 @@ security: []
 tags:
   - name: service metadata
     description: The service API provides additional metadata needed to make the OOAPI fit for this organization.
-  - name: security
-    description: |
-      Within the specification, no global security is defined. This keeps the core specification neutral and avoids 
-      prescribing a single security model for all operations. For those API calls that require authentication or 
-      authorisation, this is explicitly indicated in the accompanying documentation.
-      
-      By leaving the global security section empty, implementation details are separated from the functional description, 
-      while still providing guidance on how concrete security measures can be applied in practice.
   - name: academic sessions
     description: The academic sessions API provides information about the different time periods a program can be offered.
   - name: associations
@@ -314,6 +306,14 @@ tags:
     description: This path is no longer supported.
   - name: documents
     description: The API for accessing and retrieving document resources.
+  - name: security
+    description: |
+      Within the specification, no global security is defined. This keeps the core specification neutral and avoids 
+      prescribing a single security model for all operations. For those API calls that require authentication or 
+      authorisation, this is explicitly indicated in the accompanying documentation.
+      
+      By leaving the global security section empty, implementation details are separated from the functional description, 
+      while still providing guidance on how concrete security measures can be applied in practice.
 
   - name: service_model
     x-displayName: Service
@@ -401,11 +401,9 @@ tags:
       <SchemaDefinition schemaRef="#/components/schemas/Room" />
 
 x-tagGroups:
-  - name: Security
-    tags:
-      - security
   - name: Requests and respones
     tags: 
+      - security
       - service metadata
       - academic sessions
       - associations

--- a/v6/spec.yaml
+++ b/v6/spec.yaml
@@ -180,6 +180,14 @@ security: []
 tags:
   - name: service metadata
     description: The service API provides additional metadata needed to make the OOAPI fit for this organization.
+  - name: security
+    description: |
+      Within the specification, no global security is defined. This keeps the core specification neutral and avoids 
+      prescribing a single security model for all operations. For those API calls that require authentication or 
+      authorisation, this is explicitly indicated in the accompanying documentation.
+      
+      By leaving the global security section empty, implementation details are separated from the functional description, 
+      while still providing guidance on how concrete security measures can be applied in practice.
   - name: academic sessions
     description: The academic sessions API provides information about the different time periods a program can be offered.
   - name: associations
@@ -393,6 +401,9 @@ tags:
       <SchemaDefinition schemaRef="#/components/schemas/Room" />
 
 x-tagGroups:
+  - name: Security
+    tags:
+      - security
   - name: Requests and respones
     tags: 
       - service metadata
@@ -445,13 +456,6 @@ x-tagGroups:
 
 
 components:
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-    openId:
-      type: openIdConnect
-      openIdConnectUrl: https://example.nl/.well-known/openid-configuration
   schemas:
     Service:
       $ref: schemas/Service.yaml


### PR DESCRIPTION
Removed security from the specs as it is implementation-specific. 
Authentication and authorisation differ per environment, so defining them 
in the core specification would cause unnecessary coupling. 
Security requirements are documented separately where needed.