### PR TITLE
Add state query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0 Add state query parameter for offerings] - 2025-09-03
+
+### Added
+- Added: `state` query parameter to all `GET` requests that return a collection of offerings. Offerings now have a `state` attribute and many applications will want to retrieve only offerings with a particular state such as `active`.
+
 ## [6.0.0 Change move security to documentation] - 2025-08-28
 
 ### Added

--- a/v6/parameters/offeringState.yaml
+++ b/v6/parameters/offeringState.yaml
@@ -1,0 +1,6 @@
+name: state
+in: query
+description: Filter by an Offering's `state`.
+required: false
+schema:
+  $ref: '../enumerations/offeringState.yaml'

--- a/v6/paths/AcademicSessionCourseOfferingCollection.yaml
+++ b/v6/paths/AcademicSessionCourseOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/AcademicSessionLearningComponentOfferingCollection.yaml
+++ b/v6/paths/AcademicSessionLearningComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/AcademicSessionProgramOfferingCollection.yaml
+++ b/v6/paths/AcademicSessionProgramOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/AcademicSessionTestComponentOfferingCollection.yaml
+++ b/v6/paths/AcademicSessionTestComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/CourseCourseOfferingCollection.yaml
+++ b/v6/paths/CourseCourseOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: modeOfDelivery
       in: query
       description: Filter by modeOfDelivery

--- a/v6/paths/CourseLearningComponentOfferingCollection.yaml
+++ b/v6/paths/CourseLearningComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: modeOfDelivery
       in: query
       description: Filter by modeOfDelivery

--- a/v6/paths/CourseTestComponentOfferingCollection.yaml
+++ b/v6/paths/CourseTestComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: modeOfDelivery
       in: query
       description: Filter by modeOfDelivery

--- a/v6/paths/LearningComponentLearningComponentOfferingCollection.yaml
+++ b/v6/paths/LearningComponentLearningComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/OrganizationCourseOfferingCollection.yaml
+++ b/v6/paths/OrganizationCourseOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/OrganizationLearningComponentOfferingCollection.yaml
+++ b/v6/paths/OrganizationLearningComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/OrganizationProgramOfferingCollection.yaml
+++ b/v6/paths/OrganizationProgramOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/OrganizationTestComponentOfferingCollection.yaml
+++ b/v6/paths/OrganizationTestComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected

--- a/v6/paths/ProgramOfferingCollection.yaml
+++ b/v6/paths/ProgramOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: modeOfStudy
       in: query
       description: Filter by modeOfStudy

--- a/v6/paths/TestComponentOfferingCollection.yaml
+++ b/v6/paths/TestComponentOfferingCollection.yaml
@@ -17,6 +17,7 @@ get:
     - $ref: '../parameters/consumer.yaml'
     - $ref: '../parameters/search.yaml'
     - $ref: '../parameters/teachingLanguage.yaml'
+    - $ref: '../parameters/offeringState.yaml'
     - name: resultExpected
       in: query
       description: Filter by resultExpected


### PR DESCRIPTION
This PR adds the `state` query parameter to all `GET` requests that return a collection of Offerings. Since all Offerings now have a `state` attribute it seems reasonable to assume that clients will want to filter on that attribute.