### PR TITLE
Optimalizations on attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [6.0.0 optimalizations on attempt] - 2025-09-18
+
+### Changed
+- Summary GET /test-component-offering-associations/{testComponentOfferingAssociationId}/test-component-offering-association-attempts parameter changed from testComponentOffering to testComponentOfferingAssociationId
+- PUT and GET on TestComponentOfferingAssociationAttemptInstance changed from regular TestComponentOfferingAssociationAttempt schema to Full variant.
+
 ## [6.0.0 update 202 response ] - 2025-09-16
 
 ### Added

--- a/v6/paths/TestComponentOfferingAssociationAttemptCollection.yaml
+++ b/v6/paths/TestComponentOfferingAssociationAttemptCollection.yaml
@@ -1,5 +1,5 @@
 get:
-  summary: GET /test-component-offering-associations/{testComponentOffering}/test-component-offering-association-attempts
+  summary: GET /test-component-offering-associations/{testComponentOfferingAssociationId}/test-component-offering-association-attempts
   operationId: listTestComponentOfferingAssociationAttemptsByTestComponentOfferingAssociationId
   description: Get a list of all test component offering association attempts related to the test component offering association based on its ID.
   tags:

--- a/v6/paths/TestComponentOfferingAssociationAttemptInstance.yaml
+++ b/v6/paths/TestComponentOfferingAssociationAttemptInstance.yaml
@@ -55,7 +55,7 @@ put:
     content:
       application/json:
         schema:
-          $ref: '../schemas/TestComponentOfferingAssociationAttempt.yaml'
+          $ref: '../schemas/TestComponentOfferingAssociationAttemptFull.yaml'
 
 
   responses:


### PR DESCRIPTION
Changed on summary path parameter and updated request/response on a get and put on attempt to schema TestComponentOfferingAssociationAttemptFull to include association attributes.

Where the request already included an association id the original schema was used.