### PR TITLE
Standardise use of languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0 Standardise use of language codes ] - 2025-09-26
+
+### Added
+- added Language.yaml in schemas
+
+### Removed
+
+### Changed
+- Refer to Language.yaml from LanguageTypedString.yaml and OfferingProperties.yaml
+- Changed teachingLanguage parameter to comply to ISO4647
 
 ## [6.0.0 optimalizations on attempt] - 2025-09-18
 

--- a/v6/parameters/teachingLanguage.yaml
+++ b/v6/parameters/teachingLanguage.yaml
@@ -1,10 +1,9 @@
 name: teachingLanguage
 in: query
-description: Filter by teachingLanguage, which is a string describing the main teaching language, should be a three-letter language code as specified by ISO 639-2.
+description: Filter by teachingLanguage, which is a string describing the main teaching language, should be at least a two-letter language code as specified by ISO 6467.
 required: false
 schema:
   type: string
-  pattern: "^[a-z]{3}$"
-  minLength: 3
-  maxLength: 3
-example: nld
+  pattern: "^([a-z]{2,3})(-([A-Z]{2}|[0-9]{3}))?(-([a-z]{4}))?(-([a-z]{2}|[0-9]{3}))*(-[a-z0-9]{2,8})*(-x(-[a-z0-9]{1,8})+)?$"
+  minLength: 2
+example: nl

--- a/v6/schemas/Language.yaml
+++ b/v6/schemas/Language.yaml
@@ -1,0 +1,18 @@
+description: | 
+  The language used in the described entity. A string formatted according to RFC4647 https://www.rfc-editor.org/rfc/rfc4647.html
+  RFC4647 supports language specifications from very general to very specific. 
+  This breaks down as:
+  - ([a-z]{2,3}) - Primary language subtag (2-3 letters) ISO 639-1, ISO 639-2 or ISO 639-3 https://www.iso.org/iso-639-language-code
+  - (-([A-Z]{2}|[0-9]{3}))? - Optional region/country (2 uppercase letters or 3 digits) ISO 3166-1 or UN M.49 https://www.iso.org/iso-3166-country-codes.html
+  - (-([a-z]{4}))? - Optional script subtag (4 lowercase letters)
+  - (-([a-z]{2}|[0-9]{3}))* - Optional variant subtags
+  - (-[a-z0-9]{2,8})* - Optional extension subtags
+  - (-x(-[a-z0-9]{1,8})+)? - Optional private use extensions
+
+  When using this schema, the most common format is a two-letter language code as specified by ISO 639-1, optionally followed by a dash and a two-letter country code as specified by ISO 3166-1 (e.g. "en" or "en-GB").
+  More specific language tags are also allowed, such as "zh-Hant-TW" for Traditional Chinese as used in Taiwan.
+  For sign language based on a certain language two methods are in use: either using the subtag "sgn" (e.g. "nl-sgn-NL" for Dutch Sign Language) or using the subtag "s" (e.g. "nl-s-NL" for Dutch Sign Language). Both methods are allowed.
+type: string
+minLength: 2
+pattern: "^([a-z]{2,3})(-([A-Z]{2}|[0-9]{3}))?(-([a-z]{4}))?(-([a-z]{2}|[0-9]{3}))*(-[a-z0-9]{2,8})*(-x(-[a-z0-9]{1,8})+)?$"
+example: en-GB

--- a/v6/schemas/LanguageTypedString.yaml
+++ b/v6/schemas/LanguageTypedString.yaml
@@ -5,10 +5,7 @@ required:
   - value
 properties:
   language:
-    description: The language used in the described entity. A string formatted according to RFC3066.
-    type: string
-    pattern: "^[a-z]{2,4}(-[A-Z][a-z]{3})?(-([A-Z]{2}|[0-9]{3}))?$"
-    example: en-GB
+    $ref: '../schemas/Language.yaml'
   value:
     description: String to describe the entity.
     type: string

--- a/v6/schemas/OfferingProperties.yaml
+++ b/v6/schemas/OfferingProperties.yaml
@@ -41,7 +41,7 @@ properties:
     description: The description of this offering.
     minItems: 1
     items:
-      $ref: './LanguageTypedString.yaml'
+      $ref: '../schemas/LanguageTypedString.yaml'
     example:
     - language: en-GB
       value: |
@@ -63,15 +63,10 @@ properties:
               Perform non-parametric tests (e.g., Chi-square, Mann-Whitney, and Kruskal-Wallis)'
   teachingLanguages:
     type: array
-    description:  The languages in which this course is given, should be three-letter language codes as specified by ISO 639-2. A student should be reasonably proficient in each language to be able to follow the offering.
+    description:  The languages in which this course is given, should at least a two-letter language code as specified by ISO4647. A student should be reasonably proficient in each language to be able to follow the offering.
     minItems: 1
     items:
-      type: string
-      description: A string describing the main teaching language, should be a three-letter language code as specified by ISO 639-2.
-      minLength: 3
-      maxLength: 3
-      pattern: "^[a-z]{3}$"
-      example: nld
+      $ref: './Language.yaml'
   modesOfDelivery:
     type: array 
     items:   


### PR DESCRIPTION
Based on issue #307. Examined the different scenario's. Have chosen to make use of ISO4647 since this standard makes it possible to make use of very simple language codes like "nl" or "en" to more complex ones including language variants and sign language like "nl-sgn-NL"