### PR TITLE
Fix flexible dates so they are compatible again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - field for instructors added in courses and programmes.
 
 ### Changed
-- flexibleEntryStart and flexibleEntryEnd will be replaced with flexibleEntry.
+- flexibleEntryStart and flexibleEntryEnd have been renamed to flexibleEntryStartDateTime and flexibleEntryEndDateTime
 - teachingLanguages, refers to ISO 4647 will be corrected to RFC 4647.
 - in enrolmentPeriods, the field targetGroup should be renamed to targetGroups.
 

--- a/v6/schemas/CourseOffering.yaml
+++ b/v6/schemas/CourseOffering.yaml
@@ -21,12 +21,20 @@ allOf:
         description: The moment on which this offering ends, RFC3339 (date-time)
         format: date-time
         example: "2019-10-23T22:59:59+01:00"
-      flexibleEntry:
+      flexibleEntryPeriodStartDateTime:
         type:
-          - boolean
+          - string
           - 'null'
-        description: flexibleEntry determines whether the startDateTime and endDateTime are flexible (true) or fixed (false).
-        example: true
+        description: If this is a course wherein participants can start at various moments, without missing anything, use this attribute in combination with `flexibleEntryPeriodEndDateTime`.
+        format: date
+        example: "2019-08-21T09:00:00+01:00"
+      flexibleEntryPeriodEndDateTime:
+        type:
+          - string
+          - 'null'
+        description: If this is a course wherein participants can start at various moments, without missing anything, use this attribute in combination with `flexibleEntryPeriodStartDateTime`.
+        format: date
+        example: "2019-10-21T22:59:59+01:00"
       addresses:
         type:
           - array

--- a/v6/schemas/ProgrammeOffering.yaml
+++ b/v6/schemas/ProgrammeOffering.yaml
@@ -19,12 +19,20 @@ allOf:
         description: The moment on which this offering ends, RFC3339 (date-time)
         format: date-time
         example: '2025-12-28T08:30:00+01:00'
-      flexibleEntry:
+      flexibleEntryPeriodStartDateTime:
         type:
-          - boolean
+          - string
           - 'null'
-        description: flexibleEntry determines whether the startDateTime and endDateTime are flexible (true) or fixed (false).
-        example: true
+        description: If this is a course wherein participants can start at various moments, without missing anything, use this attribute in combination with `flexibleEntryPeriodEndDateTime`.
+        format: date
+        example: "2019-08-21T09:00:00+01:00"
+      flexibleEntryPeriodEndDateTime:
+        type:
+          - string
+          - 'null'
+        description: If this is a course wherein participants can start at various moments, without missing anything, use this attribute in combination with `flexibleEntryPeriodStartDateTime`.
+        format: date
+        example: "2019-10-21T22:59:59+01:00"
       addresses:
         type:
           - array


### PR DESCRIPTION
This PR fixes a mistake that was made by replacing the flexible entry dates with a boolean. Unfortunately just adding a boolean does not provide enough information to communicate the desired information.