### PR TITLE
Fix typo in AcademicSessionCourseOfferingCollection.yaml

### DIFF
--- a/source/paths/AcademicSessionCourseOfferingCollection.yaml
+++ b/source/paths/AcademicSessionCourseOfferingCollection.yaml
@@ -53,7 +53,9 @@ get:
                   - items
                 properties:
                   items:
-                    $ref: '../schemas/CourseOffering.yaml'
+                    type: array
+                    items:
+                      $ref: '../schemas/CourseOffering.yaml'
                   ext:
                       $ref: '../schemas/Ext.yaml'
     '400':


### PR DESCRIPTION
Body "items" property should be an array of CourseOfferings, not a single CourseOffering.